### PR TITLE
Fix valgrind issues

### DIFF
--- a/decoder.c
+++ b/decoder.c
@@ -1068,6 +1068,12 @@ SRD_API int srd_decoder_load_all(void)
 	return SRD_OK;
 }
 
+static void srd_decoder_unload_cb(void *arg, void *ignored)
+{
+	(void)ignored; // Prevent unused warning
+	srd_decoder_unload((struct srd_decoder *)arg);
+}
+
 /**
  * Unload all loaded protocol decoders.
  *
@@ -1077,8 +1083,7 @@ SRD_API int srd_decoder_load_all(void)
  */
 SRD_API int srd_decoder_unload_all(void)
 {
-	for (GSList *l = pd_list; l; l = l->next)
-		srd_decoder_unload(l->data);
+	g_slist_foreach(pd_list, srd_decoder_unload_cb, NULL);
 	g_slist_free(pd_list);
 	pd_list = NULL;
 

--- a/srd.c
+++ b/srd.c
@@ -289,6 +289,12 @@ SRD_API int srd_init(const char *path)
 	return SRD_OK;
 }
 
+static void srd_session_destroy_cb(void *arg, void *ignored)
+{
+	(void)ignored; // Prevent unused warning
+	srd_session_destroy((struct srd_session *)arg);
+}
+
 /**
  * Shutdown libsigrokdecode.
  *
@@ -307,8 +313,9 @@ SRD_API int srd_exit(void)
 {
 	srd_dbg("Exiting libsigrokdecode.");
 
-	for (GSList *l = sessions; l; l = l->next)
-		srd_session_destroy(l->data);
+	g_slist_foreach(sessions, srd_session_destroy_cb, NULL);
+	g_slist_free(sessions);
+	sessions = NULL;
 
 	srd_decoder_unload_all();
 	g_slist_free_full(searchpaths, g_free);

--- a/srd.c
+++ b/srd.c
@@ -172,6 +172,7 @@ static int print_searchpaths(void)
 		py_path = PyList_GetItem(py_paths, i);
 		py_bytes = PyUnicode_AsUTF8String(py_path);
 		g_string_append_printf(s, " - %s\n", PyBytes_AsString(py_bytes));
+		Py_DECREF(py_bytes);
 	}
 	s->str[s->len - 1] = '\0';
 	srd_dbg("%s", s->str);

--- a/tests/decoder.c
+++ b/tests/decoder.c
@@ -388,11 +388,14 @@ END_TEST
 START_TEST(test_doc_get)
 {
 	struct srd_decoder *dec;
+	char *doc;
 
 	srd_init(DECODERS_TESTDIR);
 	srd_decoder_load("uart");
 	dec = srd_decoder_get_by_id("uart");
-	fail_unless(srd_decoder_doc_get(dec) != NULL);
+	doc = srd_decoder_doc_get(dec);
+	fail_unless(doc != NULL);
+	g_free(doc);
 	srd_exit();
 }
 END_TEST

--- a/tests/session.c
+++ b/tests/session.c
@@ -148,10 +148,13 @@ static void conf_check_ok(struct srd_session *sess, int key, uint64_t x)
 static void conf_check_fail(struct srd_session *sess, int key, uint64_t x)
 {
 	int ret;
+	GVariant *value = g_variant_new_uint64(x);
 
-	ret = srd_session_metadata_set(sess, key, g_variant_new_uint64(x));
+	ret = srd_session_metadata_set(sess, key, value);
 	fail_unless(ret != SRD_OK, "srd_session_metadata_set(%p, %d, %"
 		PRIu64 ") worked.", sess, key, x);
+	if (ret != SRD_OK)
+		g_variant_unref(value);
 }
 
 static void conf_check_fail_null(struct srd_session *sess, int key)
@@ -166,10 +169,13 @@ static void conf_check_fail_null(struct srd_session *sess, int key)
 static void conf_check_fail_str(struct srd_session *sess, int key, const char *s)
 {
 	int ret;
+	GVariant *value = g_variant_new_string(s);
 
-	ret = srd_session_metadata_set(sess, key, g_variant_new_string(s));
+	ret = srd_session_metadata_set(sess, key, value);
 	fail_unless(ret != SRD_OK, "srd_session_metadata_set() for key %d "
 		"failed: %d.", key, ret);
+	if (ret != SRD_OK)
+		g_variant_unref(value);
 }
 
 /*


### PR DESCRIPTION
This fixes all the 'invalid read' and 'definitely lost' issues reported when running the tests under Valgrind. This was prompted when I saw a SEGV during exit of pulseview when unloading the decoder plugins.
```
make  check-TESTS
PASS: tests/main
============================================================================
Testsuite summary for libsigrokdecode 0.6.0
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```