### PR TITLE
DS1307: Bugs fixes.

### DIFF
--- a/decoders/ds1307/pd.py
+++ b/decoders/ds1307/pd.py
@@ -39,9 +39,9 @@ bits = (
 
 rates = {
     0b00: '1Hz',
-    0b01: '4096kHz',
-    0b10: '8192kHz',
-    0b11: '32768kHz',
+    0b01: '4096Hz',
+    0b10: '8192Hz',
+    0b11: '32768Hz',
 }
 
 DS1307_I2C_ADDRESS = 0x68
@@ -121,7 +121,7 @@ class Decoder(srd.Decoder):
         ampm_mode = True if (b & (1 << 6)) else False
         if ampm_mode:
             self.putd(6, 6, [13, ['12-hour mode', '12h mode', '12h']])
-            a = 'AM' if (b & (1 << 6)) else 'PM'
+            a = 'PM' if (b & (1 << 5)) else 'AM'
             self.putd(5, 5, [14, [a, a[0]]])
             h = self.hours = bcd2int(b & 0x1f)
             self.putd(4, 0, [15, ['Hour: %d' % h, 'H: %d' % h, 'H']])


### PR DESCRIPTION
- Square wave frequencies above 1 Hz are in Hz not in kHz.
- AM/PM flag is in the bit 5 of hours register not in bit 6.
- AM flag is valid at 0 value of AM/PM flag not at 1 value.