### PR TITLE
onewire_network: add a missing 'Resume ROM' command

### DIFF
--- a/decoders/onewire_network/pd.py
+++ b/decoders/onewire_network/pd.py
@@ -29,6 +29,7 @@ command = {
     0xec: ['Conditional search ROM', 'SEARCH ROM'],
     0x3c: ['Overdrive skip ROM'    , 'TRANSPORT' ],
     0x69: ['Overdrive match ROM'   , 'GET ROM'   ],
+    0xa5: ['Resume'                , 'TRANSPORT' ],
 }
 
 class Decoder(srd.Decoder):

--- a/decoders/onewire_network/pd.py
+++ b/decoders/onewire_network/pd.py
@@ -21,15 +21,16 @@ import sigrokdecode as srd
 
 # Dictionary of ROM commands and their names, next state.
 command = {
-    0x33: ['Read ROM'              , 'GET ROM'   ],
-    0x0f: ['Conditional read ROM'  , 'GET ROM'   ],
-    0xcc: ['Skip ROM'              , 'TRANSPORT' ],
-    0x55: ['Match ROM'             , 'GET ROM'   ],
-    0xf0: ['Search ROM'            , 'SEARCH ROM'],
-    0xec: ['Conditional search ROM', 'SEARCH ROM'],
-    0x3c: ['Overdrive skip ROM'    , 'TRANSPORT' ],
-    0x69: ['Overdrive match ROM'   , 'GET ROM'   ],
-    0xa5: ['Resume'                , 'TRANSPORT' ],
+    0x33: ['Read ROM'                  , 'GET ROM'   ],
+    0x0f: ['Conditional read ROM'      , 'GET ROM'   ],
+    0xcc: ['Skip ROM'                  , 'TRANSPORT' ],
+    0x55: ['Match ROM'                 , 'GET ROM'   ],
+    0xf0: ['Search ROM'                , 'SEARCH ROM'],
+    0xec: ['Conditional search ROM'    , 'SEARCH ROM'],
+    0x3c: ['Overdrive skip ROM'        , 'TRANSPORT' ],
+    0x69: ['Overdrive match ROM'       , 'GET ROM'   ],
+    0xa5: ['Resume'                    , 'TRANSPORT' ],
+    0x96: ['DS2408: Disable Test Mode' , 'GET ROM'   ],
 }
 
 class Decoder(srd.Decoder):


### PR DESCRIPTION
From the DS2408 datasheet [1]:
Resume Command [A5h]
In a typical application the DS2408 can be accessed several times to
complete a control or adjustment function. In a multidrop environment
this means that the 64-bit ROM sequence of a Match ROM command has to
be repeated for every access. To maximize the data throughput in a
multidrop environment, the Resume Command function is implemented.
This function checks the status of the RC flag and, if it is set,
directly transfers control to the control functions, similar to a Skip
ROM command. The only way to set the RC flag is through successfully
executing the Match ROM, Search ROM, Conditional Search ROM, or
Overdrive-Match ROM command. Once the RC flag is set, the device can
be repeatedly accessed through the Resume Command function. Accessing
another device on the bus will clear the RC flag, preventing two or
more devices from simultaneously responding to the Resume Command
function.

Refs:
[1] https://datasheets.maximintegrated.com/en/ds/DS2408.pdf