### PR TITLE
usb_power_delivery: handle extended message type in PD 3.0

### DIFF
--- a/decoders/usb_power_delivery/pd.py
+++ b/decoders/usb_power_delivery/pd.py
@@ -418,7 +418,10 @@ class Decoder(srd.Decoder):
         return ((self.head >> 6) & 3) + 1
 
     def head_type(self):
-        return self.head & 0xF
+        if self.head_rev() == 3:
+            return self.head & 0x1F
+        else:
+            return self.head & 0xF
 
     def head_count(self):
         return (self.head >> 12) & 7


### PR DESCRIPTION
The Message Type field of USB PD 3.0 messages has been extended from 4
to 5 bits[1]. While the protocol decoder already knows about the newly
defined message types (such as Get_Source_Cap_Extended), it does not
handle them correctly, because only the lower 4 bits of the header are
masked off (resulting, for example, in GoodCRC being detected, instead
of Get_Source_Cap_Extended).

Fix this by increasing the size of the Message Type field depending on
the value of the Specification Revision field.

[1] See Tables 6-1 of the USB Power Delivery Specification Revision 2.0
and Revision 3.0, respectively.