### PR TITLE
usb_packet: Handle truncated data packets.

### DIFF
--- a/decoders/usb_packet/pd.py
+++ b/decoders/usb_packet/pd.py
@@ -342,6 +342,10 @@ class Decoder(srd.Decoder):
                 self.packet_summary += ' %02X' % db
             self.packet_summary += ' ]'
 
+            if len(packet) < 32:
+                self.putp([28, ['Invalid packet (shorter than 32 bits)']])
+                return
+
             # Convenience Python output (no annotation) for all bytes together.
             self.ss, self.es = self.bits[16][1], self.bits[-16][2]
             self.putpb(['DATABYTES', databytes])


### PR DESCRIPTION
Attempting to decode a truncated data packet would raise an exception,
leaving the decoder in a state where next packet will get appended to it
and decoded as one packet.

This patch adds an explicit check for length before trying to decode the
data and CRC fields, allowing graceful handling of truncated packets.

Screenshots [before](https://bin.jvnv.net/file/ZKlmW.png), [after](https://bin.jvnv.net/file/Av4ee.png) and the actual [capture file](https://bin.jvnv.net/file/Ah8zF/dump.sr).