### PR TITLE
LPC: Improve performance by properly using conditions of self.wait, further improvement possible

### DIFF
--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -315,13 +315,9 @@ class Decoder(srd.Decoder):
         self.state = 'IDLE'
 
     def decode(self):
+        conditions = [{i: 'e'} for i in range(6)]
         while True:
-            # TODO: Come up with more appropriate self.wait() conditions.
-            pins = self.wait()
-
-            # If none of the pins changed, there's nothing to do.
-            if self.oldpins == pins:
-                continue
+            pins = self.wait(conditions)
 
             # Store current pin values for the next round.
             self.oldpins = pins


### PR DESCRIPTION
The old implementation required a lot of transitions between the C and python part.
A simple alternative is to wait for any transition.
Measuring the performance using "time ./pdtest -r lpc" I get an improvement of perfomance of factor (3.178 +/- 0.235)