### PR TITLE
Adding decoders to slice and decode logic analyzer outputs (ex: signed / unsigned / fixedpoint)

### DIFF
--- a/decoders/vector_enum_slice/__init__.py
+++ b/decoders/vector_enum_slice/__init__.py
@@ -1,0 +1,35 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+'''
+This protocol decodes sliced data from vector_slicer and generates
+annotations for an enumerated type.
+
+The mapping from the slice value to the enumeration is given by a
+json file. The following example is for a one hot coded state of an fsm:
+{
+"S1":  1,
+"S2":  2,
+"S3":  4,
+"S4":  8,
+"S5": 16
+}
+'''
+
+from .pd import Decoder

--- a/decoders/vector_enum_slice/dict.json
+++ b/decoders/vector_enum_slice/dict.json
@@ -1,0 +1,10 @@
+{
+"idle"           : 0,
+"header"         : 1,
+"low address"    : 2,
+"high address"   : 3,
+"data 0"         : 4,
+"data 1"         : 5,
+"data 2"         : 6,
+"CS"             : 7
+}

--- a/decoders/vector_enum_slice/pd.py
+++ b/decoders/vector_enum_slice/pd.py
@@ -1,0 +1,73 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+import sigrokdecode as srd
+import json
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'vector_enum'
+    name = 'vector enum slice'
+    longname = 'vector enum slice'
+    desc = 'Decoding a slice of a vector to an enum.'
+    license = 'gplv2+'
+    inputs = ['vector_slice']
+    outputs = []
+    tags = ['VectorSlicer']
+    options = (
+        {'id': 'jsonfile', 'desc': '.json path', 'default': ''},
+    )
+    annotations = (
+        ('a', 'a'),
+        ('b', 'b'),
+        ('c', 'c'),
+        ('d', 'd'),
+        ('e', 'e'),
+        ('f', 'f'),
+        ('u', 'u'), # used for undefined state
+    )
+    annotation_rows = (
+        ('enum', 'enum', tuple([i for i in range(0, len(annotations))])),
+    )
+
+    def reset(self):
+        pass
+
+    def __init__(self):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+        self.enums = {}
+        with open(self.options['jsonfile'], 'r') as myfile:
+            data = json.loads(myfile.read())
+            ann = 0
+            for key in data:
+                self.enums[data[key]] = [key, ann]
+                ann = (ann + 1) % (len(self.annotations) - 1)
+        self.u_ann = len(self.annotations)-1
+
+    def decode(self, ss, es, data):
+        d, length = data
+        if d in self.enums:
+            item, ann = self.enums[d]
+        else:
+            item = "undefined"
+            ann = self.u_ann
+        self.put(ss, es, self.out_ann, [ann, [item]])

--- a/decoders/vector_fixedpoint_slice/__init__.py
+++ b/decoders/vector_fixedpoint_slice/__init__.py
@@ -1,0 +1,25 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+'''
+This protocol decodes sliced data from vector_slicer and generates
+annotations in unsigned decimal, hexadecimal octal or binary format.
+'''
+
+from .pd import Decoder

--- a/decoders/vector_fixedpoint_slice/__init__.py
+++ b/decoders/vector_fixedpoint_slice/__init__.py
@@ -19,7 +19,16 @@
 
 '''
 This protocol decodes sliced data from vector_slicer and generates
-annotations in unsigned decimal, hexadecimal octal or binary format.
+fixed point annotations in decimal format. The point position is given by the user.
+
+Example:
+
+7 6 5 4 3 2 1 0
+1 1 0 0 0.1 0 0 (unsigned)
+
+point position = 3
+= 18.5 (decimal)
+
 '''
 
 from .pd import Decoder

--- a/decoders/vector_fixedpoint_slice/pd.py
+++ b/decoders/vector_fixedpoint_slice/pd.py
@@ -1,0 +1,79 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+import sigrokdecode as srd
+import math
+from decimal import *
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'vector_fixedpoint'
+    name = 'vector fixedpoint slice'
+    longname = 'vector fixedpoint slice'
+    desc = 'Decoding a slice of a fixedpoint vector to an integer.'
+    license = 'gplv2+'
+    inputs = ['vector_slice']
+    outputs = []
+    tags = ['VectorSlicer']
+    options = (
+        {'id': 'pos', 'desc': 'point position', 'default': 3},
+        {'id': 'Signum', 'desc': 'select signum', 'default': 'unsigned',
+            'values': ('unsigned', 'signed')},
+    )
+    annotations = (
+        ('value', 'value'),
+    )
+    annotation_rows = (
+        ('value', 'value', (0,)),
+    )
+
+    def reset(self):
+        pass
+
+    def __init__(self):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+        self.fmt_str = "{{0:.0{}f}}"
+        self.PosOfFixedPoint = self.options['pos']
+        self.fmt_str = self.fmt_str.format(self.PosOfFixedPoint)
+        self.signed = False
+        if self.options['Signum'] == 'signed':
+            self.signed = True
+
+    def decode(self, ss, es, data):
+        d, length = data
+        integer = (d & (((2**(length-self.PosOfFixedPoint))-1)<<self.PosOfFixedPoint))>>self.PosOfFixedPoint
+        fractional = (d & (2**(self.PosOfFixedPoint)-1))
+        fractional_scaled = fractional/(2**self.PosOfFixedPoint)
+
+
+        if  self.signed == True:
+            sign_integer = 1 << (length-self.PosOfFixedPoint-1)
+            sign_fractional = (1 << (self.PosOfFixedPoint))
+            if integer & sign_integer:
+                integer = integer - 2*sign_integer
+            if fractional & sign_fractional:
+                fractional_scaled = fractional_scaled - 2*sign_fractional
+
+        decimal = integer + fractional_scaled
+
+
+        self.put(ss, es, self.out_ann, [0, [self.fmt_str.format(decimal)]])

--- a/decoders/vector_fixedpoint_slice/pd.py
+++ b/decoders/vector_fixedpoint_slice/pd.py
@@ -37,10 +37,10 @@ class Decoder(srd.Decoder):
             'values': ('unsigned', 'signed')},
     )
     annotations = (
-        ('value', 'value'),
+        ('fixedpoint-value', 'fixedpoint interpretation of vector'),
     )
     annotation_rows = (
-        ('value', 'value', (0,)),
+        ('values', 'values', (0,)),
     )
 
     def reset(self):

--- a/decoders/vector_signed_slice/__init__.py
+++ b/decoders/vector_signed_slice/__init__.py
@@ -1,0 +1,26 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+'''
+This protocol decodes sliced data from vector_slicer and generates
+annotations in signed decimal integer format.
+'''
+
+
+from .pd import Decoder

--- a/decoders/vector_signed_slice/pd.py
+++ b/decoders/vector_signed_slice/pd.py
@@ -31,10 +31,10 @@ class Decoder(srd.Decoder):
     tags = ['VectorSlicer']
     options = ()
     annotations = (
-        ('value', 'slice value'),
+        ('signed-value', 'signed interpretation of vector'),
     )
     annotation_rows = (
-        ('value', 'value', (0,)),
+        ('values', 'values', (0,)),
     )
 
     def reset(self):

--- a/decoders/vector_signed_slice/pd.py
+++ b/decoders/vector_signed_slice/pd.py
@@ -1,0 +1,55 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+import sigrokdecode as srd
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'vector_signed'
+    name = 'vector signed slice'
+    longname = 'vector signed slice'
+    desc = 'Decoding a slice of a vector to a signed integer.'
+    license = 'gplv2+'
+    inputs = ['vector_slice']
+    outputs = []
+    tags = ['VectorSlicer']
+    options = ()
+    annotations = (
+        ('value', 'slice value'),
+    )
+    annotation_rows = (
+        ('value', 'value', (0,)),
+    )
+
+    def reset(self):
+        pass
+
+    def __init__(self):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+
+    def decode(self, ss, es, data):
+        d, length = data
+        sign = 1 << (length-1)
+        if d & sign:
+            d = d - 2*sign
+        self.put(ss, es, self.out_ann, [0, ["{0:d}".format(d)]])
+

--- a/decoders/vector_slicer/__init__.py
+++ b/decoders/vector_slicer/__init__.py
@@ -1,0 +1,39 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+'''
+This protocol decoder can decode multiple bits from a logic analyzer
+into a slice. A slice is a value which can further be decoded.
+
+As input it takes the data from a logic analyzer.
+It is required to use the lowest data channels, and use consecutive ones.
+For example, for a 4 bit analyzer probe, channels D0/D1/D2/D3 should be
+used. Using combinations like D7/D12/D3/D15 is not supported.
+For an 8 bit analyzer probe you should use D0-D7, for a 16 bit analyzer
+probe use D0-D15 and so on.
+
+One can configure the base in the input vector and the length of the slice.
+
+Currently the following decoders are available to annotate slices:
+    - unsigned slice: annotate slice as unsigned integer
+    - signed slice: annotate slice as signed integer
+    - enum slice: annotate slice as enumerated type
+'''
+
+from .pd import Decoder

--- a/decoders/vector_slicer/__init__.py
+++ b/decoders/vector_slicer/__init__.py
@@ -33,6 +33,7 @@ One can configure the base in the input vector and the length of the slice.
 Currently the following decoders are available to annotate slices:
     - unsigned slice: annotate slice as unsigned integer
     - signed slice: annotate slice as signed integer
+    - fixedpoint slice: annotate slice as fixedpoint number
     - enum slice: annotate slice as enumerated type
 '''
 

--- a/decoders/vector_slicer/pd.py
+++ b/decoders/vector_slicer/pd.py
@@ -1,0 +1,122 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+import sigrokdecode as srd
+from common.srdhelper import bitpack
+
+NUM_CHANNELS = 12
+
+'''
+OUTPUT_PYTHON format:
+
+Packet:
+[<item>, <itembitsize>]
+
+<item>:
+ - A single item (a number). It can be of arbitrary size. The max. number
+   of bits in this item is specified in <itembitsize>.
+
+<itembitsize>:
+ - The size of an item (in bits). For a 4-bit parallel bus this is 4,
+   for a 16-bit parallel bus this is 16, and so on.
+'''
+
+class ChannelError(Exception):
+    pass
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'vector_slicer'
+    name = 'vector slicer'
+    longname = 'vector slicer'
+    desc = 'Take a slice of a vector.'
+    license = 'gplv2+'
+    inputs = ['logic']
+    outputs = ['vector_slice']
+    tags = ['VectorSlicer']
+    optional_channels = tuple([{'id': 'd%d' % i, 'name': 'D%d' % i, 'desc': 'Data line %d' % i} for i in range(NUM_CHANNELS)])
+    options = (
+        {'id': 'index',  'desc': 'index in vector of bottom (lsb) bit',           'default': 0},
+        {'id': 'length', 'desc': 'number of bits in vector to decode as integer', 'default': 8},
+    )
+    annotations = ()
+    annotation_rows = ()
+
+    def reset(self):
+        pass
+
+    def __init__(self):
+        self.reset()
+
+    def start(self):
+        self.out_python = self.register(srd.OUTPUT_PYTHON)
+
+        left = self.options['index']
+        if left < 0:
+            left = 0
+        length = self.options['length']
+        if length <= 1:
+            raise ChannelError('length has to be at least 2')
+
+        mask = 1
+        for i in range(0, length-1):
+            mask = (mask << 1) | mask;
+
+        self.left = left
+        self.length = length
+        self.mask = mask
+
+        self.first = True
+
+    def decode_pins(self, pins, idx_strip):
+        bits = [0 if idx is None else pins[idx] for idx in self.idx_channels]
+        item = bitpack(bits[0:idx_strip])
+
+        item = (item >> self.left) & self.mask
+
+        if not self.first:
+            if item != self.last_item:
+                self.put(self.ss_item, self.samplenum, self.out_python, [self.last_item, self.length])
+                self.ss_item = self.samplenum
+        else:
+            self.ss_item = self.samplenum
+        self.last_item = item
+        self.first = False
+
+    def decode(self):
+        # Determine which channels have input data.
+        max_possible = len(self.optional_channels)
+        self.idx_channels = [
+            idx if self.has_channel(idx) else None
+            for idx in range(max_possible)
+        ]
+        has_channels = [idx for idx in self.idx_channels if idx is not None]
+        if not has_channels:
+            raise ChannelError('At least one channel has to be supplied.')
+        max_connected = max(has_channels)
+
+        conds = [{idx: 'e'} for idx in has_channels]
+        idx_strip = max_connected + 1
+
+        # Keep processing the input stream. Assume "always zero" for
+        # not-connected input lines.
+        self.decode_pins(self.wait(), idx_strip)
+        while True:
+            self.decode_pins(self.wait(conds), idx_strip)
+

--- a/decoders/vector_unsigned_slice/__init__.py
+++ b/decoders/vector_unsigned_slice/__init__.py
@@ -1,0 +1,25 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+'''
+This protocol decodes sliced data from vector_slicer and generates
+annotations in unsigned decimal, hexadecimal octal or binary format.
+'''
+
+from .pd import Decoder

--- a/decoders/vector_unsigned_slice/pd.py
+++ b/decoders/vector_unsigned_slice/pd.py
@@ -1,0 +1,77 @@
+##
+## This file is part of the libsigrokdecode project.
+##
+## Copyright (C) 2019 Comlab AG
+##
+## This program is free software; you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation; either version 2 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program; if not, see <http://www.gnu.org/licenses/>.
+##
+
+import sigrokdecode as srd
+import math
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'vector_unsigned'
+    name = 'vector unsigned slice'
+    longname = 'vector unsigned slice'
+    desc = 'Decoding a slice of a vector to an unsigned integer.'
+    license = 'gplv2+'
+    inputs = ['vector_slice']
+    outputs = []
+    tags = ['VectorSlicer']
+    options = (
+        {'id': 'format', 'desc': 'select format', 'default': 'decimal',
+            'values': ('dec', 'hex', 'oct', 'bin')},
+    )
+    annotations = (
+        ('value', 'value'),
+    )
+    annotation_rows = (
+        ('value', 'value', (0,)),
+    )
+
+    def reset(self):
+        pass
+
+    def __init__(self):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+
+        fmt_opt = self.options['format']
+        self.fmt_str = "{0:d}"
+        if fmt_opt == 'hex':
+            self.fmt_str = "0x{{0:0{}x}}"
+        elif fmt_opt == 'oct':
+            self.fmt_str = "0o{{0:0{}o}}"
+        elif fmt_opt == 'bin':
+            self.fmt_str = "b{{0:0{}b}}"
+
+        self.fmt_opt = fmt_opt
+        self.first = True
+
+    def decode(self, ss, es, data):
+        d, length = data
+        if self.first:
+            if self.fmt_opt == 'bin':
+                self.fmt_str = self.fmt_str.format(length)
+            elif self.fmt_opt == 'hex':
+                l = math.floor((length + 3)/4)
+                self.fmt_str = self.fmt_str.format(l)
+            elif self.fmt_opt == 'oct':
+                l = math.floor((length + 2)/3)
+                self.fmt_str = self.fmt_str.format(l)
+        self.first = False
+        self.put(ss, es, self.out_ann, [0, [self.fmt_str.format(d)]])

--- a/decoders/vector_unsigned_slice/pd.py
+++ b/decoders/vector_unsigned_slice/pd.py
@@ -35,10 +35,10 @@ class Decoder(srd.Decoder):
             'values': ('dec', 'hex', 'oct', 'bin')},
     )
     annotations = (
-        ('value', 'value'),
+        ('unsigned-value', 'unsigned interpretation of vector'),
     )
     annotation_rows = (
-        ('value', 'value', (0,)),
+        ('values', 'values', (0,)),
     )
 
     def reset(self):


### PR DESCRIPTION
vector_slicer is used as base (stack) for the vector_fixed_point_slice, vector_signed_slice and vector_unsigned_slice which are able to decode fixed-point, signed and unsigned representation of any bitwidth.
UseCase is the debugging of FPGA designs. The decoders give a number representation instead of a lot of singel bits.

There is also the vector_enum_slice decoder which can be used to decode vectors with configurable (code -> name pairs in JSON file) mapping. This is useful to debug for example state machines. Sadly PulseView crashes sometimes when using this decoder. Maybe there is a better idea to solve this.

Known problems:
- The last state of a vector is not decoded (decoder receives no event because there is no change at the end of a trace). This is fr all vector_???_slice decoders
- When vector_enum_slice decoder is used PulseView crahes sometimes.