### PR TITLE
Increment Py_True and Py_False reference counts

### DIFF
--- a/type_decoder.c
+++ b/type_decoder.c
@@ -1130,7 +1130,10 @@ static PyObject *Decoder_has_channel(PyObject *self, PyObject *args)
 
 	PyGILState_Release(gstate);
 
-	return (di->dec_channelmap[idx] == -1) ? Py_False : Py_True;
+	if (di->dec_channelmap[idx] == -1)
+		Py_RETURN_FALSE;
+	else
+		Py_RETURN_TRUE;
 
 err:
 	PyGILState_Release(gstate);


### PR DESCRIPTION
Use Py_RETURN_TRUE and Py_RETURN_FALSE to properly increment
reference count of Python boolean objects

In reference to https://sigrok.org/bugzilla/show_bug.cgi?id=1671