### PR TITLE
Build: Fix building as a DLL on Windows

### DIFF
--- a/libsigrokdecode.h
+++ b/libsigrokdecode.h
@@ -107,16 +107,20 @@ enum srd_loglevel {
 
 /* Marks public libsigrokdecode API symbols. */
 #ifndef _WIN32
-#define SRD_API __attribute__((visibility("default")))
+	#define SRD_API __attribute__((visibility("default")))
 #else
-#define SRD_API
+	#ifdef DLL_EXPORT
+		#define SRD_API __declspec(dllexport)
+	#else
+		#define SRD_API extern
+	#endif
 #endif
 
 /* Marks private, non-public libsigrokdecode symbols (not part of the API). */
 #ifndef _WIN32
-#define SRD_PRIV __attribute__((visibility("hidden")))
+	#define SRD_PRIV __attribute__((visibility("hidden")))
 #else
-#define SRD_PRIV
+	#define SRD_PRIV
 #endif
 
 /*


### PR DESCRIPTION
Building as a DLL on Windows would result in the DLL having no exports because of an export from a Python API inclusion. Solving this simply involves changing the SRD_API define to use __declspec(dllexport) when building as a DLL on Windows and retaining the __attribute__((visibility("default"))) on non-Windows builds.