### PR TITLE
Fix LPC decoder

### DIFF
--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -128,13 +128,15 @@ class Decoder(srd.Decoder):
         ('addr', 'Address'),
         ('tar1', 'Turn-around cycle 1'),
         ('sync', 'Sync'),
-        ('data', 'Data'),
+        ('server-data', 'Server Data'),
         ('tar2', 'Turn-around cycle 2'),
         ('lad', 'LAD bus'),
+        ('peripheral-data', 'Peripheral Data'),
     )
     annotation_rows = (
         ('lad-vals', 'LAD bus', (8,)),
-        ('data-vals', 'Data', (1, 2, 3, 4, 5, 6, 7)),
+        ('server-vals', 'Server', (1, 2, 3, 4, 6)),
+        ('periherals-vals', 'Peripheral', (5, 7, 9)),
         ('warnings', 'Warnings', (0,)),
     )
 
@@ -310,7 +312,10 @@ class Decoder(srd.Decoder):
             return
 
         self.es_block = self.samplenum
-        self.putb([6, ['DATA: 0x%02x' % self.databyte]])
+        if self.cycle_type in ('I/O write', 'Memory write'):
+            self.putb([6, ['DATA: 0x%02x' % self.databyte]])
+        else:
+            self.putb([9, ['DATA: 0x%02x' % self.databyte]])
         self.ss_block = self.samplenum
 
         if self.cycle_type in ('I/O write', 'Memory write'):

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -147,6 +147,7 @@ class Decoder(srd.Decoder):
         self.cycle_type = -1
         self.databyte = 0
         self.tarcount = 0
+        self.sync_type = 0
         self.synccount = 0
         self.oldpins = None
         self.ss_block = self.es_block = None
@@ -259,10 +260,10 @@ class Decoder(srd.Decoder):
         # LAD[3:0]: SYNC field (1-n clock cycles).
 
         self.sync_val = lad_bits
-        self.cycle_type = fields['SYNC'].get(lad, 'Reserved / unknown')
+        self.sync_type = fields['SYNC'].get(lad, 'Reserved / unknown')
 
         # TODO: Warnings if reserved value are seen?
-        if 'Reserved' in self.cycle_type:
+        if 'Reserved' in self.sync_type:
             self.putb([0, ['SYNC, cycle %d: %s (reserved value)' % \
                            (self.synccount, self.sync_val)]])
 

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -356,11 +356,17 @@ class Decoder(srd.Decoder):
         return
 
     def decode(self):
-        # Only look at the signals upon rising LCLK edges. The LPC clock
+        # When idle, look for lframe low (asserted) and rising LCLK edge
+        # This allows us to skip over rising clock edges when idle
+        idle_conditions = [{0: 'l', 1: 'r'}]
+        # When not idle, only look for rising LCLK edges. The LPC clock
         # is the same as the PCI clock (which is sampled at rising edges).
-        conditions = [{1: 'r'}]
+        non_idle_conditions = [{1: 'r'}]
         while True:
-            pins = self.wait(conditions)
+            if self.state == 'IDLE':
+                pins = self.wait(idle_conditions)
+            else:
+                pins = self.wait(non_idle_conditions)
 
             # Store current pin values for the next round.
             self.oldpins = pins

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -331,7 +331,7 @@ class Decoder(srd.Decoder):
         # the host or peripheral tri-states LAD[3:0], but its value
         # should still be 1111, due to pull-ups on the LAD lines.
         if lad_bits != '1111':
-            self.putb([0, ['Warning: TAR, cycle %d: %s (expected 1111)'
+            self.putb([0, ['TAR, cycle %d: %s (expected 1111)'
                            % (self.tarcount, lad_bits)]])
 
         self.ss_block = self.samplenum

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -130,8 +130,10 @@ class Decoder(srd.Decoder):
         ('sync', 'Sync'),
         ('data', 'Data'),
         ('tar2', 'Turn-around cycle 2'),
+        ('lad', 'LAD bus'),
     )
     annotation_rows = (
+        ('lad-vals', 'LAD bus', (8,)),
         ('data-vals', 'Data', (1, 2, 3, 4, 5, 6, 7)),
         ('warnings', 'Warnings', (0,)),
     )
@@ -153,6 +155,7 @@ class Decoder(srd.Decoder):
         self.synccount = 0
         self.oldpins = None
         self.ss_block = self.es_block = None
+        self.ss_cycle = None
 
     def start(self):
         self.out_ann = self.register(srd.OUTPUT_ANN)
@@ -379,7 +382,10 @@ class Decoder(srd.Decoder):
             # Most (but not all) states need this.
             if self.state != 'IDLE':
                 lad_bits = '{:04b}'.format(self.lad)
-                # self.putb([0, ['LAD: %s' % lad_bits]])
+                self.put(self.ss_cycle, self.samplenum, self.out_ann, [8, ['%s' % lad_bits]])
+
+            # Save the cycle of the last lclk rising edge
+            self.ss_cycle = self.samplenum
 
             # TODO: Only memory read/write is currently supported/tested.
 

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -141,7 +141,6 @@ class Decoder(srd.Decoder):
 
     def reset(self):
         self.state = 'IDLE'
-        self.oldlclk = -1
         self.lad = -1
         self.addr = 0
         self.cur_nibble = 0
@@ -315,7 +314,9 @@ class Decoder(srd.Decoder):
         self.state = 'IDLE'
 
     def decode(self):
-        conditions = [{i: 'e'} for i in range(6)]
+        # Only look at the signals upon rising LCLK edges. The LPC clock
+        # is the same as the PCI clock (which is sampled at rising edges).
+        conditions = [{1: 'r'}]
         while True:
             pins = self.wait(conditions)
 
@@ -325,12 +326,6 @@ class Decoder(srd.Decoder):
             # Get individual pin values into local variables.
             (lframe, lclk, lad0, lad1, lad2, lad3) = pins[:6]
             (lreset, ldrq, serirq, clkrun, lpme, lpcpd, lsmi) = pins[6:]
-
-            # Only look at the signals upon rising LCLK edges. The LPC clock
-            # is the same as the PCI clock (which is sampled at rising edges).
-            if not (self.oldlclk == 0 and lclk == 1):
-                self.oldlclk = lclk
-                continue
 
             # Store LAD[3:0] bit values (one nibble) in local variables.
             # Most (but not all) states need this.

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -203,7 +203,7 @@ class Decoder(srd.Decoder):
             self.state = 'IDLE'
             return
 
-        self.putb([2, ['Cycle type: %s' % self.cycle_type]])
+        self.putb([2, ['Cycle type: %s' % self.cycle_type, "%s" % self.cycle_type]])
 
         if self.cycle_type in ('DMA read', 'DMA write'):
             self.putb([0, ['DMA cycle decoding not supported']])

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -174,7 +174,6 @@ class Decoder(srd.Decoder):
         self.putb([1, [fields['START'][self.lad], 'START', 'St', 'S']])
 
         # Output a warning if LAD[3:0] changes while LFRAME# is low.
-        # TODO
         if (self.prev_lad != -1 and self.prev_lad != self.lad):
             self.putb([0, ['LAD[3:0] changed while LFRAME# was asserted']])
 
@@ -288,8 +287,6 @@ class Decoder(srd.Decoder):
         self.putb([5, ['SYNC, cycle %d: %s' % (self.synccount, self.sync_val)]])
         self.ss_block = self.samplenum
 
-        # TODO
-
         if self.cycle_type in ('I/O write', 'Memory write'):
             self.state = 'GET TAR2'
             self.cycle_count = 0
@@ -387,7 +384,7 @@ class Decoder(srd.Decoder):
             # Save the cycle of the last lclk rising edge
             self.ss_cycle = self.samplenum
 
-            # TODO: Only memory read/write is currently supported/tested.
+            # TODO: Need to implement DMA and firmware cycle decode
 
             # At any stage, if lframe is asserted with LAD=1111, then the
             # transaction is aborted

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -231,8 +231,12 @@ class Decoder(srd.Decoder):
         self.putb([3, [s % self.addr]])
         self.ss_block = self.samplenum
 
-        self.state = 'GET TAR'
-        self.tar_count = 0
+        if self.cycle_type in ('I/O write', 'Memory write'):
+            self.state = 'GET DATA'
+            self.cycle_count = 0
+        else:
+            self.state = 'GET TAR'
+            self.tar_count = 0
 
     def handle_get_tar(self, lad, lad_bits):
         # LAD[3:0]: First TAR (turn-around) field (2 clock cycles).
@@ -273,8 +277,12 @@ class Decoder(srd.Decoder):
 
         # TODO
 
-        self.cycle_count = 0
-        self.state = 'GET DATA'
+        if self.cycle_type in ('I/O write', 'Memory write'):
+            self.state = 'GET TAR2'
+            self.cycle_count = 0
+        else:
+            self.cycle_count = 0
+            self.state = 'GET DATA'
 
     def handle_get_data(self, lad, lad_bits):
         # LAD[3:0]: DATA field (2 clock cycles).
@@ -295,8 +303,12 @@ class Decoder(srd.Decoder):
         self.putb([6, ['DATA: 0x%02x' % self.databyte]])
         self.ss_block = self.samplenum
 
-        self.cycle_count = 0
-        self.state = 'GET TAR2'
+        if self.cycle_type in ('I/O write', 'Memory write'):
+            self.state = 'GET TAR'
+            self.tar_count = 0
+        else:
+            self.state = 'GET TAR2'
+            self.cycle_count = 0
 
     def handle_get_tar2(self, lad, lad_bits):
         # LAD[3:0]: Second TAR field (2 clock cycles).

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -248,7 +248,7 @@ class Decoder(srd.Decoder):
         self.cycle_count = 0
 
     def handle_get_idsel(self, lad_bits):
-        self.put_cycle([Ann.IDSEL, ['IDSEL: %s' % (lad_bits), 'IDSEL']])
+        self.put_cycle([Ann.IDSEL, ['IDSEL: %s' % (lad_bits), 'IDSEL', 'ID', 'I']])
 
         self.state = St.GET_ADDR
         self.ss_block = self.samplenum
@@ -299,7 +299,7 @@ class Decoder(srd.Decoder):
             self.state = St.IDLE
             return
 
-        self.put_cycle([Ann.MSIZE, ['MSIZE: %s bytes' % (msize_bytes), 'MSIZE']])
+        self.put_cycle([Ann.MSIZE, ['MSIZE: %s bytes' % (msize_bytes), 'MSIZE', 'M']])
         self.data_nibbles = 2*msize_bytes
 
         if self.cycle_type == CycType.FW_READ:
@@ -313,14 +313,14 @@ class Decoder(srd.Decoder):
     def handle_get_tar(self, lad_bits):
         # LAD[3:0]: First TAR (turn-around) field (2 clock cycles).
 
-        self.put_cycle([Ann.TAR1, ['TAR, cycle %d: %s' % (self.cycle_count, lad_bits)]])
+        self.put_cycle([Ann.TAR1, ['TAR1: cycle %d' % (self.cycle_count), 'TAR1', 'T']])
 
         # On the first TAR clock cycle LAD[3:0] is driven to 1111 by
         # either the host or peripheral. On the second clock cycle,
         # the host or peripheral tri-states LAD[3:0], but its value
         # should still be 1111, due to pull-ups on the LAD lines.
         if lad_bits != '1111':
-            self.put_cycle([Ann.WARNING, ['TAR, cycle %d: %s (expected 1111)' % \
+            self.put_cycle([Ann.WARNING, ['TAR1: cycle %d: %s (expected 1111)' % \
                            (self.cycle_count, lad_bits)]])
 
         if (self.cycle_count != 1):
@@ -338,7 +338,7 @@ class Decoder(srd.Decoder):
         if 'Reserved' in sync_type:
             self.put_cycle([Ann.WARNING, ['SYNC %s (reserved value)' % sync_type]])
 
-        self.put_cycle([Ann.SYNC, ['SYNC: %s' % sync_type]])
+        self.put_cycle([Ann.SYNC, ['SYNC: %s' % sync_type, 'SYNC', 'Sy', 'S']])
 
         # Long or short wait
         if 'wait' in sync_type:
@@ -380,14 +380,14 @@ class Decoder(srd.Decoder):
     def handle_get_tar2(self, lad_bits):
         # LAD[3:0]: Second TAR field (2 clock cycles).
 
-        self.put_cycle([Ann.TAR2, ['TAR, cycle %d: %s' % (self.cycle_count, lad_bits)]])
+        self.put_cycle([Ann.TAR2, ['TAR2: cycle %d' % (self.cycle_count), 'TAR2', 'T']])
 
         # On the first TAR clock cycle LAD[3:0] is driven to 1111 by
         # either the host or peripheral. On the second clock cycle,
         # the host or peripheral tri-states LAD[3:0], but its value
         # should still be 1111, due to pull-ups on the LAD lines.
         if lad_bits != '1111':
-            self.put_cycle([Ann.WARNING, ['TAR, cycle %d: %s (expected 1111)'
+            self.put_cycle([Ann.WARNING, ['TAR2: cycle %d: %s (expected 1111)'
                            % (self.cycle_count, lad_bits)]])
 
         if (self.cycle_count != 1):

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -24,12 +24,12 @@ from common.srdhelper import SrdIntEnum
 fields = {
     # START field (indicates start or stop of a transaction)
     'START': {
-        0b0000: 'Start of cycle for a target',
+        0b0000: 'Target',
         0b0010: 'Grant for bus master 0',
         0b0011: 'Grant for bus master 1',
-        0b1101: 'Start of cycle for a Firmware Memory Read cycle',
-        0b1110: 'Start of cycle for a Firmware Memory Write cycle',
-        0b1111: 'Stop/abort (end of a cycle for a target)',
+        0b1101: 'Firmware Memory Read',
+        0b1110: 'Firmware Memory Write',
+        0b1111: 'Stop/abort',
     },
     # Cycle type / direction field
     # Bit 0 (LAD[0]) is unused, should always be 0.
@@ -172,7 +172,7 @@ class Decoder(srd.Decoder):
         # multiple clocks, and we output all START fields that occur, even
         # though the peripherals are supposed to ignore all but the last one.
         start_str = fields['START'].get(self.lad, 'Reserved')
-        self.put_cycle([Ann.START, [start_str, 'START', 'St', 'S']])
+        self.put_cycle([Ann.START, ['START: %s' % start_str, 'START', 'St', 'S']])
 
         # Output a warning if LAD[3:0] changes while LFRAME# is low.
         if (self.prev_lad != -1 and self.prev_lad != self.lad):
@@ -185,10 +185,10 @@ class Decoder(srd.Decoder):
         if lframe != 1:
             return
 
-        if 'Firmware Memory Read cycle' in start_str:
+        if 'Firmware Memory Read' in start_str:
             self.cycle_type = CycType.FW_READ
             self.state = St.GET_IDSEL
-        elif 'Firmware Memory Write cycle' in start_str:
+        elif 'Firmware Memory Write' in start_str:
             self.cycle_type = CycType.FW_WRITE
             self.state = St.GET_IDSEL
         else:

--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -25,18 +25,8 @@ fields = {
     # START field (indicates start or stop of a transaction)
     'START': {
         0b0000: 'Start of cycle for a target',
-        0b0001: 'Reserved',
         0b0010: 'Grant for bus master 0',
         0b0011: 'Grant for bus master 1',
-        0b0100: 'Reserved',
-        0b0101: 'Reserved',
-        0b0110: 'Reserved',
-        0b0111: 'Reserved',
-        0b1000: 'Reserved',
-        0b1001: 'Reserved',
-        0b1010: 'Reserved',
-        0b1011: 'Reserved',
-        0b1100: 'Reserved',
         0b1101: 'Start of cycle for a Firmware Memory Read cycle',
         0b1110: 'Start of cycle for a Firmware Memory Write cycle',
         0b1111: 'Stop/abort (end of a cycle for a target)',
@@ -51,8 +41,6 @@ fields = {
         0b0110: 'Memory write',
         0b1000: 'DMA read',
         0b1010: 'DMA write',
-        0b1100: 'Reserved / not allowed',
-        0b1110: 'Reserved / not allowed',
     },
     # SIZE field (determines how many bytes are to be transferred)
     # Bits[3:2] are reserved, must be driven to 0b00.
@@ -60,7 +48,6 @@ fields = {
     'SIZE': {
         0b0000: '8 bits (1 byte)',
         0b0001: '16 bits (2 bytes)',
-        0b0010: 'Reserved / not allowed',
         0b0011: '32 bits (4 bytes)',
     },
     # CHANNEL field (bits[2:0] contain the DMA channel number)
@@ -77,21 +64,10 @@ fields = {
     # SYNC field (used to add wait states)
     'SYNC': {
         0b0000: 'Ready',
-        0b0001: 'Reserved',
-        0b0010: 'Reserved',
-        0b0011: 'Reserved',
-        0b0100: 'Reserved',
         0b0101: 'Short wait',
         0b0110: 'Long wait',
-        0b0111: 'Reserved',
-        0b1000: 'Reserved',
         0b1001: 'Ready more (DMA only)',
         0b1010: 'Error',
-        0b1011: 'Reserved',
-        0b1100: 'Reserved',
-        0b1101: 'Reserved',
-        0b1110: 'Reserved',
-        0b1111: 'Reserved',
     },
     # MSIZE field (determines how many bytes to transfer in a firmware cycle)
     'MSIZE': {
@@ -195,7 +171,7 @@ class Decoder(srd.Decoder):
         # the peripherals must use. However, the host can keep LFRAME# asserted
         # multiple clocks, and we output all START fields that occur, even
         # though the peripherals are supposed to ignore all but the last one.
-        start_str = fields['START'][self.lad]
+        start_str = fields['START'].get(self.lad, 'Reserved')
         self.put_cycle([Ann.START, [start_str, 'START', 'St', 'S']])
 
         # Output a warning if LAD[3:0] changes while LFRAME# is low.
@@ -221,7 +197,7 @@ class Decoder(srd.Decoder):
     def handle_get_ct_dr(self, lad_bits):
         # LAD[3:0]: Cycle type / direction field (1 clock cycle).
 
-        cycle_type_str = fields['CT_DR'].get(self.lad, 'Reserved / unknown')
+        cycle_type_str = fields['CT_DR'].get(self.lad, 'Reserved')
 
         self.put_cycle([Ann.CYCLE_TYPE, ['Cycle type: %s' % cycle_type_str, "%s" % cycle_type_str]])
 
@@ -333,7 +309,7 @@ class Decoder(srd.Decoder):
     def handle_get_sync(self, lad_bits):
         # LAD[3:0]: SYNC field (1-n clock cycles).
 
-        sync_type = fields['SYNC'].get(self.lad, 'Reserved / unknown')
+        sync_type = fields['SYNC'].get(self.lad, 'Reserved')
 
         if 'Reserved' in sync_type:
             self.put_cycle([Ann.WARNING, ['SYNC %s (reserved value)' % sync_type]])


### PR DESCRIPTION
This series fixes a number of issues in the LPC decoder, including:

- Correctly detect clock rising edge
- Handle various errors better
- Speed up decode
- Handle LPC abort (lframe going high)
- Add memory and I/O writes and firmware cycles
- Handle sync short/long wait
- Use more recent sigrok helpers

To verify this a number of captures from both x86-64 and POWER9 systems were added to sigrok-dumps
[here](https://github.com/sigrokproject/sigrok-dumps/pull/36)