### PR TITLE
I2S bug: Handle case where initial WS pin is 0

### DIFF
--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -146,7 +146,7 @@ class Decoder(srd.Decoder):
 
                 self.samplesreceived += 1
 
-                sck = self.wait({0: 'f'})
+                self.wait({0: 'f'})
 
                 idx = 0 if not self.oldws else 1
                 c1 = 'Left channel' if not self.oldws else 'Right channel'
@@ -165,7 +165,7 @@ class Decoder(srd.Decoder):
 
                 self.wordlength = self.bitcount
             else:
-                sck = self.wait({0: 'f'})
+                self.wait({0: 'f'})
 
             # Reset decoder state.
             self.data = 0

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -19,6 +19,7 @@
 
 import sigrokdecode as srd
 import struct
+from common.srdhelper import SrdIntEnum
 
 '''
 OUTPUT_PYTHON format:
@@ -32,6 +33,8 @@ Packet:
 <channel>: 'L' or 'R'
 <value>: integer
 '''
+
+Pin = SrdIntEnum.from_str('Pin', 'SCK WS SD')
 
 class Decoder(srd.Decoder):
     api_version = 3
@@ -131,7 +134,7 @@ class Decoder(srd.Decoder):
     def decode(self):
         while True:
             # Wait for a rising edge on the SCK pin.
-            sck, ws, sd = self.wait({0: 'r'})
+            sck, ws, sd = self.wait({Pin.SCK: 'r'})
 
             # Shift the data in, one SCK at a time
             self.data = (self.data << 1) | sd
@@ -150,7 +153,7 @@ class Decoder(srd.Decoder):
 
                 self.samplesreceived += 1
 
-                self.wait({0: 'f'})
+                self.wait({Pin.SCK: 'f'})
 
                 c1 = 'Left channel' if not self.oldws else 'Right channel'
                 c2 = 'Left' if not self.oldws else 'Right'
@@ -172,7 +175,7 @@ class Decoder(srd.Decoder):
 
                 self.wordlength = self.bitcount
             else:
-                self.wait({0: 'f'})
+                self.wait({Pin.SCK: 'f'})
 
             # Reset decoder state.
             self.data = 0

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -81,12 +81,15 @@ class Decoder(srd.Decoder):
             self.samplerate = value
 
     def putpb(self, data):
+        """Output Python data"""
         self.put(self.ss_block, self.samplenum, self.out_python, data)
 
     def putbin(self, data):
+        """Output binary data"""
         self.put(self.ss_block, self.samplenum, self.out_binary, data)
 
     def putb(self, data):
+        """Output annotations"""
         self.put(self.ss_block, self.samplenum, self.out_ann, data)
 
     def report(self):
@@ -130,6 +133,7 @@ class Decoder(srd.Decoder):
             # Wait for a rising edge on the SCK pin.
             sck, ws, sd = self.wait({0: 'r'})
 
+            # Shift the data in, one SCK at a time
             self.data = (self.data << 1) | sd
             self.bitcount += 1
 

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -148,14 +148,17 @@ class Decoder(srd.Decoder):
 
                 self.wait({0: 'f'})
 
-                idx = 0 if not self.oldws else 1
                 c1 = 'Left channel' if not self.oldws else 'Right channel'
                 c2 = 'Left' if not self.oldws else 'Right'
                 c3 = 'L' if not self.oldws else 'R'
                 v = '%08x' % self.data
                 self.putpb(['DATA', [c3, self.data]])
-                self.putb([idx, ['%s: %s' % (c1, v), '%s: %s' % (c2, v),
-                                 '%s: %s' % (c3, v), c3]])
+
+                idx = 0 if not self.oldws else 1
+                self.putb([idx, ['%s: %s' % (c1, v),
+                                 '%s: %s' % (c2, v),
+                                 '%s: %s' % (c3, v),
+                                 c3]])
                 self.putbin([0, self.wav_sample(self.data)])
 
                 # Check that the data word was the correct length.


### PR DESCRIPTION
`oldws` was initialized to 1, and then watched for changes, so:

- If the signal started with WS=1, it would work correctly.
- If the signal started with WS=0, the first sample would be considered a
transition of WS, and the first few bits would be decoded, even though
they are not a complete word.

![2022-01-19 13_17_55-small I2S sample sr - PulseView](https://user-images.githubusercontent.com/58611/150373422-dfcaaaad-c0ed-4836-a176-a7a55efda97e.png)

This handles the initial conditions better, so only the first complete sample is decoded:

![2022-01-19 14_37_51-small I2S sample sr - PulseView](https://user-images.githubusercontent.com/58611/150373642-a551fa8d-7212-4fc3-932b-95d9d9405de7.png)


(This branch is based on https://github.com/sigrokproject/libsigrokdecode/pull/79)