### PR TITLE
I2S bug: WAV errors halt entire decoder

### DIFF
--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -129,7 +129,10 @@ class Decoder(srd.Decoder):
         return h
 
     def wav_sample(self, sample):
-        return struct.pack('<I', self.data)
+        try:
+            return struct.pack('<I', self.data)
+        except struct.error:
+            return struct.pack('<I', 0)
 
     def decode(self):
         while True:

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -146,7 +146,7 @@ class Decoder(srd.Decoder):
 
                 self.samplesreceived += 1
 
-                sck = self.wait({0: 'f'})
+                self.wait({0: 'f'})
 
                 idx = 0 if not self.oldws else 1
                 c1 = 'Left channel' if not self.oldws else 'Right channel'
@@ -165,7 +165,7 @@ class Decoder(srd.Decoder):
 
                 self.wordlength = self.bitcount
             else:
-                sck = self.wait({0: 'f'})
+                self.wait({0: 'f'})
 
             # Reset decoder state.
             self.data = 0

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -19,6 +19,7 @@
 
 import sigrokdecode as srd
 import struct
+from common.srdhelper import SrdIntEnum
 
 '''
 OUTPUT_PYTHON format:
@@ -32,6 +33,8 @@ Packet:
 <channel>: 'L' or 'R'
 <value>: integer
 '''
+
+Pin = SrdIntEnum.from_str('Pin', 'SCK WS SD')
 
 class Decoder(srd.Decoder):
     api_version = 3
@@ -131,7 +134,7 @@ class Decoder(srd.Decoder):
     def decode(self):
         while True:
             # Wait for a rising edge on the SCK pin.
-            sck, ws, sd = self.wait({0: 'r'})
+            sck, ws, sd = self.wait({Pin.SCK: 'r'})
 
             # Shift the data in, one SCK at a time
             self.data = (self.data << 1) | sd
@@ -150,7 +153,7 @@ class Decoder(srd.Decoder):
 
                 self.samplesreceived += 1
 
-                self.wait({0: 'f'})
+                self.wait({Pin.SCK: 'f'})
 
                 c1 = 'Left channel' if not self.oldws else 'Right channel'
                 c2 = 'Left' if not self.oldws else 'Right'
@@ -172,7 +175,7 @@ class Decoder(srd.Decoder):
 
                 self.wordlength = self.bitcount
             else:
-                self.wait({0: 'f'})
+                self.wait({Pin.SCK: 'f'})
 
             # Reset decoder state.
             self.data = 0

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -81,12 +81,15 @@ class Decoder(srd.Decoder):
             self.samplerate = value
 
     def putpb(self, data):
+        """Output Python data"""
         self.put(self.ss_block, self.samplenum, self.out_python, data)
 
     def putbin(self, data):
+        """Output binary data"""
         self.put(self.ss_block, self.samplenum, self.out_binary, data)
 
     def putb(self, data):
+        """Output annotations"""
         self.put(self.ss_block, self.samplenum, self.out_ann, data)
 
     def report(self):
@@ -130,6 +133,7 @@ class Decoder(srd.Decoder):
             # Wait for a rising edge on the SCK pin.
             sck, ws, sd = self.wait({0: 'r'})
 
+            # Shift the data in, one SCK at a time
             self.data = (self.data << 1) | sd
             self.bitcount += 1
 

--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -148,14 +148,17 @@ class Decoder(srd.Decoder):
 
                 self.wait({0: 'f'})
 
-                idx = 0 if not self.oldws else 1
                 c1 = 'Left channel' if not self.oldws else 'Right channel'
                 c2 = 'Left' if not self.oldws else 'Right'
                 c3 = 'L' if not self.oldws else 'R'
                 v = '%08x' % self.data
                 self.putpb(['DATA', [c3, self.data]])
-                self.putb([idx, ['%s: %s' % (c1, v), '%s: %s' % (c2, v),
-                                 '%s: %s' % (c3, v), c3]])
+
+                idx = 0 if not self.oldws else 1
+                self.putb([idx, ['%s: %s' % (c1, v),
+                                 '%s: %s' % (c2, v),
+                                 '%s: %s' % (c3, v),
+                                 c3]])
                 self.putbin([0, self.wav_sample(self.data)])
 
                 # Check that the data word was the correct length.


### PR DESCRIPTION
Since WAV files must have a constant bit depth throughout, if the bit
depth of an I2S stream changes (such as stopping one transmission and
starting a new one in the same recording), the WAV output fails with:

```
    srd: return struct.pack('
    struct.error: argument out of range
```

This then causes the entire decoder to fail, with "Decoder reported an
error" and decoding annotations stop after that point:

![2022-01-19 14_47_45-small I2S sample sr - PulseView](https://user-images.githubusercontent.com/58611/150374151-c9fc5de4-ab65-4109-a0ae-5d40af5a2554.png)

With this commit, errors in bit depth are ignored in the WAV output,
replacing those samples with 0, and the decoder continues.  If the I2S
stream stops and starts, the resulting WAV will have at least one zero
sample and then will continue.

![2022-01-20 10_56_03-small I2S sample sr - PulseView](https://user-images.githubusercontent.com/58611/150374389-181a0a18-df7e-485d-8ee6-b68479416c42.png)

A better solution would be to output separate WAV files for each consistent chunk of data (whether from SCLK stopping and starting, or from WS changing frequency), but this commit at least prevents the decoder from failing.

(This branch is based on https://github.com/sigrokproject/libsigrokdecode/pull/79)