### PR TITLE
I2S bug: Incorrect I2S WAV header calculations

### DIFF
--- a/decoders/i2s/pd.py
+++ b/decoders/i2s/pd.py
@@ -114,8 +114,8 @@ class Decoder(srd.Decoder):
         h += b'\x01\x00'         # Audio format (0x0001 == PCM)
         h += b'\x02\x00'         # Number of channels (2)
         h += b'\x80\x3e\x00\x00' # Samplerate (16000)
-        h += b'\x00\xfa\x00\x00' # Byterate (64000)
-        h += b'\x04\x00'         # Blockalign (4)
+        h += b'\x00\xf4\x01\x00' # Byterate (16000*4*2 = 128000)
+        h += b'\x08\x00'         # Blockalign (4*2 = 8)
         h += b'\x20\x00'         # Bits per sample (32)
         # Data subchunk
         h += b'data'


### PR DESCRIPTION
See http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/WAVE.html

These two values need to be multiplied by the number of channels, too.

    "Each sample is M bytes long" (M = 32/8 = 4)
    nAvgBytesPerSec  4  F*M*Nc
    nBlockAlign      2  M*Nc


Better yet see [the original spec](http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/WAVE/Docs/riffmci.pdf):

> The wBlockAlign field should be equal to the following formula, rounded to the next whole number:  
wChannels x wBitsPerSample / 8

2 * 32 / 8 = 8

> For PCM data, the wAvgBytesPerSec field...

Also says to multiply by channel, [though it says `wBitsPerSecond` where it should say `dwSamplesPerSec`](https://sharkysoft.com/archive/lava/docs/javadocs/lava/riff/wave/doc-files/riffwave-content.htm#Pulse%20Code%20Modulation%20Format).