### PR TITLE
tpm: add decoders for Trusted Platform Module (TPM) communication.

### DIFF
--- a/decoders/tpm_fifo_tis/__init__.py
+++ b/decoders/tpm_fifo_tis/__init__.py
@@ -1,0 +1,24 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+'''
+Decode the TPM commands and responses contained in an TIS transaction stream
+'''
+
+from .pd import Decoder

--- a/decoders/tpm_fifo_tis/pd.py
+++ b/decoders/tpm_fifo_tis/pd.py
@@ -1,0 +1,84 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+import sigrokdecode as srd
+
+from . import tpm_fifo_tis
+
+
+def _finish_annotations(annotations):
+    '''Depending on the amount of data read/written, sometimes the data-less formats (e.g. 'write 11 bytes') end up longer than the ones with data ('write 1234').
+    In those cases, we remove them, because if we have the space to show the data, and now have sigrok pick the longer but less informative string.
+    Assume :param annotations: is sorted by preference, and throw out any longer annotations following shorter ones.'''
+    finished = [annotations[0]]
+    for ann in annotations[1:]:
+        if len(ann) < len(finished[-1]):
+            finished.append(ann)
+    return finished
+
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'tpm_fifo_tis'
+    name = 'TPM FIFO'
+    longname = 'Trusted Platform Module Commands over TIS 2.0 interface'
+    desc = 'Trusted Platform Module Commands over TIS 2.0 interface'
+    license = 'gplv3+'
+    inputs = ['tpm-tis']
+    outputs = ['tpm']
+    tags = ['TPM']
+    annotations = tpm_fifo_tis.ANNOTATIONS
+    annotation_rows = (
+        ('register', 'Register Transaction', (tpm_fifo_tis.ANN_REG_READ, tpm_fifo_tis.ANN_REG_WRITE)),
+        ('tpm', 'TPM Command/Response', (tpm_fifo_tis.ANN_TPM_CMD, tpm_fifo_tis.ANN_TPM_RSP)),
+        ('warnings', 'Warnings', (tpm_fifo_tis.ANN_WARN,)),
+        ('states', 'TPM States', (tpm_fifo_tis.ANN_STATE,)),
+    )
+
+    def __init__(self, **kwargs):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+        self.out_py = self.register(srd.OUTPUT_PYTHON)
+
+    def reset(self):
+        self._decoder = None
+
+    def _reset_decoder(self):
+        self._decoder = iter(tpm_fifo_tis.decoder(self.out_ann, self.out_py))
+        ann = self._decoder.send(None)
+        while ann is not None:
+            self.put(*ann)
+            ann = self._decoder.send(None)
+
+    def decode(self, ss, es, data):
+        ptype, xfer = data
+        if ptype != 'TRANSACTION':
+            return
+
+        if self._decoder is None:
+            self._reset_decoder()
+        try:
+            ann = self._decoder.send((ss, es, xfer))
+            while ann is not None:
+                self.put(*ann)
+                ann = self._decoder.send(None)
+        except StopIteration:
+            self._decoder = None

--- a/decoders/tpm_fifo_tis/tpm_fifo_tis.py
+++ b/decoders/tpm_fifo_tis/tpm_fifo_tis.py
@@ -1,0 +1,522 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+import binascii
+import enum
+
+from collections import defaultdict
+
+from .tpm_tis_registers import decode_register, is_power_of_two, xfer_annotations
+
+TPM_STS_X = 0x0018
+TPM_STS_stsValid = 0x80
+TPM_STS_commandReady = 0x40
+TPM_STS_tpmGo = 0x20
+TPM_STS_dataAvail = 0x10
+TPM_STS_Expect = 0x08
+TPM_STS_selfTestDone = 0x04
+TPM_STS_responseRetry = 0x02
+
+TPM_STS_read_mask = TPM_STS_commandReady | TPM_STS_dataAvail | TPM_STS_Expect
+TPM_STS_write_mask = TPM_STS_commandReady | TPM_STS_tpmGo | TPM_STS_responseRetry
+
+TPM_DATA_FIFO_X = 0x0024
+
+ANNOTATIONS = (
+    ('register-read', 'Register Read'),
+    ('register-write', 'Register Write'),
+    ('tpm-command', 'TPM Command'),
+    ('tpm-response', 'TPM Response'),
+    ('warning', 'Warning'),
+    ('state', 'State'),
+)
+# sigrokdecoder annotation indices
+ANN_REG_READ = 0
+ANN_REG_WRITE = 1
+ANN_TPM_CMD = 2
+ANN_TPM_RSP = 3
+ANN_WARN = 4
+ANN_STATE = 5
+
+TIMEOUT_B = 0  # TODO
+
+TPM_COMMAND_CODE_NAMES = defaultdict(lambda: "Unknown", {
+    0x0000011f: "NV_UndefineSpaceSpecial",
+    0x00000120: "EvictControl",
+    0x00000121: "HierarchyControl",
+    0x00000122: "NV_UndefineSpace",
+    0x00000124: "ChangeEPS",
+    0x00000125: "ChangePPS",
+    0x00000126: "Clear",
+    0x00000127: "ClearControl",
+    0x00000128: "ClockSet",
+    0x00000129: "HierarchyChangeAuth",
+    0x0000012a: "NV_DefineSpace",
+    0x0000012b: "PCR_Allocate",
+    0x0000012c: "PCR_SetAuthPolicy",
+    0x0000012d: "PP_Commands",
+    0x0000012e: "SetPrimaryPolicy",
+    0x0000012f: "FieldUpgradeStart",
+    0x00000130: "ClockRateAdjust",
+    0x00000131: "CreatePrimary",
+    0x00000132: "NV_GlobalWriteLock",
+    0x00000133: "GetCommandAuditDigest",
+    0x00000134: "NV_Increment",
+    0x00000135: "NV_SetBits",
+    0x00000136: "NV_Extend",
+    0x00000137: "NV_Write",
+    0x00000138: "NV_WriteLock",
+    0x00000139: "DictionaryAttackLockReset",
+    0x0000013a: "DictionaryAttackParameters",
+    0x0000013b: "NV_ChangeAuth",
+    0x0000013c: "PCR_Event",
+    0x0000013d: "PCR_Reset",
+    0x0000013e: "SequenceComplete",
+    0x0000013f: "SetAlgorithmSet",
+    0x00000140: "SetCommandCodeAuditStatus",
+    0x00000141: "FieldUpgradeData",
+    0x00000142: "IncrementalSelfTest",
+    0x00000143: "SelfTest",
+    0x00000144: "Startup",
+    0x00000145: "Shutdown",
+    0x00000146: "StirRandom",
+    0x00000147: "ActivateCredential",
+    0x00000148: "Certify",
+    0x00000149: "PolicyNV",
+    0x0000014a: "CertifyCreation",
+    0x0000014b: "Duplicate",
+    0x0000014c: "GetTime",
+    0x0000014d: "GetSessionAuditDigest",
+    0x0000014e: "NV_Read",
+    0x0000014f: "NV_ReadLock",
+    0x00000150: "ObjectChangeAuth",
+    0x00000151: "PolicySecret",
+    0x00000152: "Rewrap",
+    0x00000153: "Create",
+    0x00000154: "ECDH_ZGen",
+    0x00000155: "HMAC",
+    0x00000156: "Import",
+    0x00000157: "Load",
+    0x00000158: "Quote",
+    0x00000159: "RSA_Decrypt",
+    0x0000015b: "HMAC_Start",
+    0x0000015c: "SequenceUpdate",
+    0x0000015d: "Sign",
+    0x0000015e: "Unseal",
+    0x00000160: "PolicySigned",
+    0x00000161: "ContextLoad",
+    0x00000162: "ContextSave",
+    0x00000163: "ECDH_KeyGen",
+    0x00000164: "EncryptDecrypt",
+    0x00000165: "FlushContext",
+    0x00000167: "LoadExternal",
+    0x00000168: "MakeCredential",
+    0x00000169: "NV_ReadPublic",
+    0x0000016a: "PolicyAuthorize",
+    0x0000016b: "PolicyAuthValue",
+    0x0000016c: "PolicyCommandCode",
+    0x0000016d: "PolicyCounterTimer",
+    0x0000016e: "PolicyCpHash",
+    0x0000016f: "PolicyLocality",
+    0x00000170: "PolicyNameHash",
+    0x00000171: "PolicyOR",
+    0x00000172: "PolicyTicket",
+    0x00000173: "ReadPublic",
+    0x00000174: "RSA_Encrypt",
+    0x00000176: "StartAuthSession",
+    0x00000177: "VerifySignature",
+    0x00000178: "ECC_Parameters",
+    0x00000179: "FirmwareRead",
+    0x0000017a: "GetCapability",
+    0x0000017b: "GetRandom",
+    0x0000017c: "GetTestResult",
+    0x0000017d: "Hash",
+    0x0000017e: "PCR_Read",
+    0x0000017f: "PolicyPCR",
+    0x00000180: "PolicyRestart",
+    0x00000181: "ReadClock",
+    0x00000182: "PCR_Extend",
+    0x00000183: "PCR_SetAuthValue",
+    0x00000184: "NV_Certify",
+    0x00000185: "EventSequenceComplete",
+    0x00000186: "HashSequenceStart",
+    0x00000187: "PolicyPhysicalPresence",
+    0x00000188: "PolicyDuplicationSelect",
+    0x00000189: "PolicyGetDigest",
+    0x0000018a: "TestParms",
+    0x0000018b: "Commit",
+    0x0000018c: "PolicyPassword",
+    0x0000018d: "ZGen_2Phase",
+    0x0000018e: "EC_Ephemeral",
+    0x0000018f: "PolicyNvWritten",
+    0x00000190: "PolicyTemplate",
+    0x00000191: "CreateLoaded",
+    0x00000192: "PolicyAuthorizeNV",
+    0x00000193: "EncryptDecrypt2",
+    0x00000194: "AC_GetCapability",
+    0x00000195: "AC_Send",
+    0x00000196: "Policy_AC_SendSelect",
+    0x00000197: "CertifyX509",
+    0x00000198: "ACT_SetTimeout",
+    0x20000000: "Vendor_TCG_Test",
+})
+TPM_RESPONSE_CODE_NAMES = defaultdict(lambda: "Error: Unknown", {
+    0x0000: "Success",
+    0x001E: "Error: Bad Tag",
+    0x0100: "Error: Initialize",
+    0x0101: "Error: Failure",
+    0x0103: "Error: Sequence",
+    0x010B: "Error: Private",
+    0x0119: "Error: Hmac",
+    0x0120: "Error: Disabled",
+    0x0121: "Error: Exclusive",
+    0x0124: "Error: Auth Type",
+    0x0125: "Error: Auth Missing",
+    0x0126: "Error: Policy",
+    0x0127: "Error: PCR",
+    0x0128: "Error: Pcr Changed",
+    0x012D: "Error: Upgrade",
+    0x012E: "Error: Too Many Contexts",
+    0x012F: "Error: Auth Unavailable",
+    0x0130: "Error: Reboot",
+    0x0131: "Error: Unbalanced",
+    0x0142: "Error: Command Size",
+    0x0143: "Error: Command Code",
+    0x0144: "Error: Authsize",
+    0x0145: "Error: Auth Context",
+    0x0146: "Error: NV Range",
+    0x0147: "Error: NV Size",
+    0x0148: "Error: NV Locked",
+    0x0149: "Error: NV Authorization",
+    0x014A: "Error: NV Uninitialized",
+    0x014B: "Error: NV Space",
+    0x014C: "Error: NV Defined",
+    0x0150: "Error: Bad Context",
+    0x0151: "Error: Cphash",
+    0x0152: "Error: Parent",
+    0x0153: "Error: Needs Test",
+    0x0154: "Error: No Result",
+    0x0155: "Error: Sensitive",
+    0x017F: "Error: Max Fm0",
+    0x0081: "Error: Asymmetric",
+    0x0082: "Error: Attributes",
+    0x0083: "Error: Hash",
+    0x0084: "Error: Value",
+    0x0085: "Error: Hierarchy",
+    0x0087: "Error: Key Size",
+    0x0088: "Error: Mgf",
+    0x0089: "Error: Mode",
+    0x008A: "Error: Type",
+    0x008B: "Error: Handle",
+    0x008C: "Error: Kdf",
+    0x008D: "Error: Range",
+    0x008E: "Error: Auth Fail",
+    0x008F: "Error: Nonce",
+    0x0090: "Error: Pp",
+    0x0092: "Error: Scheme",
+    0x0095: "Error: Size",
+    0x0096: "Error: Symmetric",
+    0x0097: "Error: Tag",
+    0x0098: "Error: Selector",
+    0x009A: "Error: Insufficient",
+    0x009B: "Error: Signature",
+    0x009C: "Error: Key",
+    0x009D: "Error: Policy Fail",
+    0x009F: "Error: Integrity",
+    0x00A0: "Error: Ticket",
+    0x00A1: "Error: Reserved Bits",
+    0x00A2: "Error: Bad Auth",
+    0x00A3: "Error: Expired",
+    0x00A4: "Error: Policy Cc",
+    0x00A5: "Error: Binding",
+    0x00A6: "Error: Curve",
+    0x00A7: "Error: Ecc Point",
+    0x0901: "Error: Context Gap",
+    0x0902: "Error: Object Memory",
+    0x0903: "Error: Session Memory",
+    0x0904: "Error: Memory",
+    0x0905: "Error: Session Handles",
+    0x0906: "Error: Object Handles",
+    0x0907: "Error: Locality",
+    0x0908: "Error: Yielded",
+    0x0909: "Error: Canceled",
+    0x090A: "Error: Testing",
+    0x0910: "Error: Reference H0",
+    0x0911: "Error: Reference H1",
+    0x0912: "Error: Reference H2",
+    0x0913: "Error: Reference H3",
+    0x0914: "Error: Reference H4",
+    0x0915: "Error: Reference H5",
+    0x0916: "Error: Reference H6",
+    0x0918: "Error: Reference S0",
+    0x0919: "Error: Reference S1",
+    0x091A: "Error: Reference S2",
+    0x091B: "Error: Reference S3",
+    0x091C: "Error: Reference S4",
+    0x091D: "Error: Reference S5",
+    0x091E: "Error: Reference S6",
+    0x0920: "Error: NV Rate",
+    0x0921: "Error: Lockout",
+    0x0922: "Error: Retry",
+    0x0923: "Error: NV Unavailable",
+    0x097F: "Error: Not Used",
+})
+
+def _annotate_tpm_command(data):
+    tag = data[0:2]
+    size = data[2:6]
+    cmd_code = int.from_bytes(data[6:10], byteorder='big')
+    data = binascii.hexlify(data).upper().decode()
+    return [
+        "{cmd_code_name} ({cmd_code:04X}): {data}".format(cmd_code_name=TPM_COMMAND_CODE_NAMES[cmd_code], cmd_code=cmd_code, data=data),
+        "{cmd_code_name} ({cmd_code:04X})".format(cmd_code_name=TPM_COMMAND_CODE_NAMES[cmd_code], cmd_code=cmd_code),
+        '[{data_len} bytes]'.format(data_len=len(data))
+    ]
+
+def _annotate_tpm_response(data):
+    tag = data[0:2]
+    size = data[2:6]
+    rsp_code = int.from_bytes(data[6:10], byteorder='big')
+    data = binascii.hexlify(data).upper().decode()
+    return [
+        "{cmd_code_name} ({cmd_code:04X}): {data}".format(cmd_code_name=TPM_RESPONSE_CODE_NAMES[rsp_code], cmd_code=rsp_code, data=data),
+        "{cmd_code_name} ({cmd_code:04X})".format(cmd_code_name=TPM_RESPONSE_CODE_NAMES[rsp_code], cmd_code=rsp_code),
+        '[{data_len} bytes]'.format(data_len=len(data))
+    ]
+
+class TpmState(enum.Enum):
+    Unknown = 0
+    Idle = 1
+    Ready = 2
+    Reception = 3
+    Execution = 4
+    Completion = 5
+
+
+def _annotate_bytes(data):
+    return [
+        binascii.hexlify(data).upper().decode(),
+        '[{data_len} bytes]'.format(data_len=len(data))
+    ]
+
+
+class decoder:
+    def __init__(self, out_ann, out_py):
+        self.out_ann = out_ann
+        self.out_py = out_py
+
+        self.state = TpmState.Unknown
+        self.state_finished = False  # Reception and Completion states use Expect/dataAvailable flags to say whether they expect/have more data. If not, they are finished
+        self.state_start = None  # time stamp the current state started
+        self.command_buffer = bytearray()
+        self.command_start = None  # must be set when state is Completion
+        self.response_buffer = bytearray()
+        self.response_start = None  # bust be set when state is Reception
+
+    def __iter__(self):
+        '''Generator. Takes (ss, es, xfer) tuples via generator send(). Yields (ss, es, ann, labels) annotations.
+        The general protocol is:
+            - For a fresh generator, send(None).
+            - Whenever this generator yields None, the next iteration should send((ss, es, xfer)).
+            - Whenever this generator yields a tuple, that is an annotation that should be put(), and the next iteration should send(None).
+        '''
+        try:
+            while True:
+                ss, es, xfer = yield from self._transaction()
+                if xfer.reading:
+                    yield from self._on_read(xfer.addr, xfer.data, ss, es)
+                else:
+                    yield from self._on_write(xfer.addr, xfer.data, ss, es)
+        except GeneratorExit:
+            if self.state_start is not None:
+                yield (self.state_start, es, self.out_ann, [ANN_STATE, [str(self.state)]])
+
+    def _warn(self, ss, es, warning):
+        if not isinstance(warning, list):
+            warning = [warning]
+        yield (ss, es, self.out_ann, [ANN_WARN, warning])
+
+    def _transaction(self):
+        '''Generator. Takes (ss, es, xfer) tuples via generator send(). Yields (ss, es, ann, labels) annotations. Returns an (ss, es, xfer) tuple.
+        Use as follows to receive a new transaction:
+            ss, es, xfer = yield from _transaction()
+        '''
+        ss, es, xfer = yield None
+
+        if xfer.addr > 0xff and xfer.addr & 0xffff0000 != 0x00d40000:
+            yield from self._warn(ss, es, 'Invalid FIFO Register address {xfer_addr:08X}'.format(xfer_addr=xfer.addr))
+            return
+
+        annotations = xfer_annotations(xfer)
+
+        yield (ss, es, self.out_ann, [ANN_REG_READ if xfer.reading else ANN_REG_WRITE, annotations])
+        return (ss, es, xfer)
+
+    def _set_state(self, new_state, new_state_start):
+        '''Generator. Yields (ss, es, ann, labels) annotations.
+        Use this as follows when a state transition is detected:
+            yield from _set_state(new_state, new_state_start)
+        '''
+        if new_state == self.state:
+            return
+        if self.state_start is not None:
+            yield (self.state_start, new_state_start, self.out_ann, [ANN_STATE, [str(self.state)]])
+        self.state = new_state
+        self.state_start = new_state_start
+        if new_state == TpmState.Reception or new_state == TpmState.Completion:
+            self.state_finished = False
+
+    def _reset_response(self, ss=None, data=None):
+        self.response_buffer.clear()
+        self.response_start = ss
+        if data:
+            self.response_buffer.extend(data)
+
+    def _reset_command(self, ss=None, data=None):
+        self.command_buffer.clear()
+        self.command_start = ss
+        if data:
+            self.command_buffer.extend(data)
+
+    def _on_read(self, reg, data, ss, es):
+        if reg & 0xfff == TPM_STS_X:
+            status = data[0]
+
+            if self.state == TpmState.Unknown:
+                if status & (TPM_STS_commandReady | TPM_STS_dataAvail) == TPM_STS_commandReady:
+                    yield from self._set_state(TpmState.Ready, ss)
+                elif status & TPM_STS_Expect:
+                    yield from self._set_state(TpmState.Reception, ss)
+                elif status & TPM_STS_dataAvail:
+                    yield from self._set_state(TpmState.Completion, ss)
+            if self.state == TpmState.Idle:
+                if status & (TPM_STS_commandReady | TPM_STS_dataAvail) == TPM_STS_commandReady:
+                    yield from self._set_state(TpmState.Ready, ss)
+                elif status & TPM_STS_read_mask != 0:
+                    yield from self._warn(ss, es, "Read status values that are unexpected in IDLE state")
+                    yield from self._set_state(TpmState.Unknown, ss)
+                    yield from self._on_read(reg, data, ss, es)  # now in Unknown state
+            elif self.state == TpmState.Ready:
+                if status & TPM_STS_read_mask == TPM_STS_Expect:
+                    yield from self._set_state(TpmState.Reception, ss)
+                elif status & (TPM_STS_commandReady | TPM_STS_dataAvail) != TPM_STS_commandReady:
+                    yield from self._warn(ss, es, "Read status values that are unexpected in READY state: {}".format(status))
+                    yield from self._set_state(TpmState.Unknown, ss)
+                    yield from self._on_read(reg, data, ss, es)  # now in Unknown state
+            elif self.state == TpmState.Reception:
+                if status & TPM_STS_stsValid and not status & TPM_STS_Expect:
+                    self.state_finished = True
+            elif self.state == TpmState.Execution:
+                if status & TPM_STS_read_mask == TPM_STS_dataAvail:
+                    self._reset_response(ss)
+                    yield from self._set_state(TpmState.Completion, ss)
+                elif status & TPM_STS_read_mask != 0:
+                    yield from self._warn(ss, es, "Read status values that are unexpected in IDLE state")
+                    yield from self._set_state(TpmState.Unknown, ss)
+                    yield from self._on_read(reg, data, ss, es)  # now in Unknown state
+            elif self.state == TpmState.Completion:
+                if status & TPM_STS_read_mask == 0:
+                    yield (self.response_start, es, self.out_ann, [ANN_TPM_RSP, _annotate_tpm_response(self.response_buffer)])
+                    yield (self.response_start, es, self.out_py, ['RESPONSE', bytes(self.response_buffer)])
+                    self.state_finished = True
+                    self._reset_response()
+                    yield from self._set_state(TpmState.Idle, ss)
+                elif status & TPM_STS_stsValid and status & TPM_STS_read_mask != TPM_STS_dataAvail:
+                    yield from self._warn(ss, es, "Read status values that are unexpected in IDLE state")
+                    yield from self._set_state(TpmState.Unknown, ss)
+                    yield from self._on_read(reg, data, ss, es)  # now in Unknown state
+
+        elif reg & 0xfff == TPM_DATA_FIFO_X:
+            if self.state == TpmState.Completion:
+                if self.state_finished:
+                    yield from self._warn(ss, es, "The TPM does not report more data dataAvailable, so this will just be 0xFFs")
+                else:
+                    self.response_buffer.extend(data)
+                # Note: if the client does not detect when the TPM clears dataAvail, it will read FFs into this buffer
+            else:
+                yield from self._warn(ss, es, "TPM does not have any data, and will return 0xFFs")
+
+    def _on_write(self, reg, data, ss, es):
+        if reg & 0xfff == TPM_STS_X:
+            status = data[0]
+            if not is_power_of_two(status):
+                yield from self._warn(ss, es, "Only one field may be set at a time when writing to TPM_STS_X")
+                yield from self._set_state(TpmState.Unknown, ss)
+                return
+
+            if self.state == TpmState.Idle:
+                if status & TPM_STS_responseRetry:
+                    yield from self._warn(ss, es, "There is no response to retry")
+                elif status & TPM_STS_tpmGo:
+                    yield from self._warn(ss, es, "There is no command to execute")
+                elif status & TPM_STS_commandReady:
+                    yield from self._set_state(TpmState.Ready, ss)
+            elif self.state == TpmState.Ready:
+                if status & TPM_STS_responseRetry:
+                    yield from self._warn(ss, es, "commandReady indicates respose has already been successfully read")
+                elif status & TPM_STS_tpmGo:
+                    yield from self._warn(ss, es, "There is no command to execute")
+                elif status & TPM_STS_commandReady:
+                    yield from self._warn(ss, es, "TPM is already ready to receive commands")
+            elif self.state == TpmState.Reception:
+                if status & TPM_STS_responseRetry:
+                    yield from self._warn(ss, es, "There is no response to retry")
+                elif status & TPM_STS_commandReady:
+                    yield from self._warn(ss, es, "Command aborted (while sending command)")
+                    self._reset_command()
+                    yield from self._set_state(TpmState.Idle, es)
+                elif status & TPM_STS_tpmGo:
+                    if not self.state_finished:
+                        yield from self._warn(ss, es, "TPM is still expecting data, so this tpmGo signal is ignored")
+                    else:  # assume everything is kosher, though this MAY be an invalid transition!  # TODO: transition to Unkown in the unknown case?
+                        yield (self.command_start, ss, self.out_ann, [ANN_TPM_CMD, _annotate_tpm_command(self.command_buffer)])
+                        yield (self.command_start, ss, self.out_py, ['COMMAND', bytes(self.command_buffer)])
+                        self._reset_command()
+                        yield from self._set_state(TpmState.Execution, ss)
+            elif self.state == TpmState.Execution:
+                if status & TPM_STS_responseRetry:
+                    yield from self._warn(ss, es, "There is no response to retry")
+                elif status & TPM_STS_tpmGo:
+                    yield from self._warn(ss, es, "Command is already executing")
+                elif status & TPM_STS_commandReady:
+                    yield from self._warn(ss, es, "Command aborted (while executing command)")
+                    yield from self._set_state(TpmState.Idle, es)
+            elif self.state == TpmState.Completion:
+                if status & TPM_STS_responseRetry:
+                    yield from self._warn(self.response_start, ss, "TPM resets ReadFIFO pointers and starts sending the response from the first byte")
+                    self._reset_response(ss)
+                elif status & TPM_STS_tpmGo:
+                    yield from self._warn(ss, es, "There is no command to execute")
+                elif status & TPM_STS_commandReady:
+                    yield from self._warn(self.response_start, ss, "Command aborted (while receiving response)")
+                    self._reset_response()
+                    yield from self._set_state(TpmState.Idle, es)
+
+        if reg & 0xfff == TPM_DATA_FIFO_X:
+            if self.state == TpmState.Ready or self.state == TpmState.Idle:  # the TPM is allowed to implicitly transition to idle; without reading the status register, we can't know this, so we just allow it here. Technically, starting to send data in the Idle state is just dropped. TODO: make this some sort of flag?
+                self._reset_command(ss)
+                self.command_buffer.extend(data)
+                yield from self._set_state(TpmState.Reception, ss)
+            elif self.state == TpmState.Reception:
+                if self.state_finished:
+                    yield from self._warn(ss, es, "The TPM is not expecting more data, so this will be dropped")
+                else:
+                    self.command_buffer.extend(data)
+            else:
+                yield from self._warn(ss, es, "TPM is not expecting data and will drop writes")

--- a/decoders/tpm_fifo_tis/tpm_tis_registers.py
+++ b/decoders/tpm_fifo_tis/tpm_tis_registers.py
@@ -1,0 +1,294 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+import binascii
+import warnings
+
+
+def is_power_of_two(value):
+    return value > 0 and (value & (value - 1) == 0)
+
+
+def _reserved_zero(value, reading, field, **kwargs):
+    '''A reserved field that is zero.
+    On reading, warn on nonzero and drop to None.
+    On writing, warn on nonzero and drop to None.'''
+    if value != 0:
+        if reading:
+            warnings.warn('Reserved field {name!r}: should return 0; returned {value!r} instead'.format(name=field["name"], value=value))
+        else:
+            warnings.warn('Reserved field {name!r}: should not be written to; value {value!r} will be ignored'.format(name=field["name"], value=value))
+    return None
+
+
+def _check_write_single_1bit(value, field, **kwargs):
+    if not is_power_of_two(value):
+        warnings.warn('Only writes with a single bit set are allowed for field {name!r}'.format(name=field["name"]))
+    return value
+
+
+def _reg_read_only(value, reading, field, **kwargs):
+    if not reading:
+        warnings.warn('The entire register {name!r} is read-only; value {value!r} will be ignored'.format(name=field["name"], value=value))
+        return None
+    return value
+
+
+_REG_TPM_ACCESS = [
+    {'bits': 7, 'name': 'tpmRegValidSts', 'w': [_reserved_zero]},
+    {'bits': 6, 'name': 'Reserved', 'rw': [_reserved_zero]},
+    {'bits': 5, 'name': 'activeLocality',
+        'r': [{0: None}],
+        'w': [{1: '1 (relinquish)', 0: None}],
+    },
+    {'bits': 4, 'name': 'beenSeized',
+        'r': [{0: None}],
+        'w': [{1: '1 (clear)', 0: None}]
+    },
+    {'bits': 3, 'name': 'Seize',
+        'r': [_reserved_zero],
+        'w': [{1: '1 (seize)', 0: None}],
+    },
+    {'bits': 2, 'name': 'pendingRequest',
+        'r': [{0: None}],
+        'w': [_reserved_zero],
+    },
+    {'bits': 1, 'name': 'requestUse',
+        'r': [{0: None}],
+        'w': [{1: '1 (request)', 0: None}],
+    },
+    {'bits': 0, 'name': 'tpmEstablishment',
+        'r': [{0: None}],
+        'w': [_reserved_zero]
+    },
+]
+
+_REG_TPM_STATUS = [
+    {'bits': (31, 0), 'name': "TPM_STS_x",  # covering the entire register, to enforce this requirement
+        'w': [_check_write_single_1bit, None],
+        'r': [None],
+    },
+    {'bits': (31, 28), 'name': 'reserved', 'rw': [_reserved_zero]},
+    {'bits': (27, 26), 'name': 'tpmFamily',
+        'r': [{0: 'TPM1_2', 1: 'TPM2_0', None: '<undefined>'}],
+        'w': [_reserved_zero],
+    },
+    {'bits': 25, 'name': 'resetEstablishmentBit',
+        'r': [_reserved_zero],
+        'w': [{0: None, 1: '1 (reset)'}],
+    },
+    {'bits': 24, 'name': 'commandCancel',
+        'r': [_reserved_zero],
+        'w': [{0: None, 1: '1 (cancel)'}],
+    },
+    {'bits': (23, 8), 'name': 'burstCount', 'w': [_reserved_zero]},
+    {'bits': 7, 'name': 'stsValid', 'w': [_reserved_zero]},
+    {'bits': 6, 'name': 'commandReady', 'rw': [{0: None}]},
+    {'bits': 5, 'name': 'tpmGo',
+        'r': [_reserved_zero],
+        'w': [{0: None}],
+    },
+    {'bits': 4, 'name': 'dataAvail',
+        'r': [{0: None}],
+        'w': [_reserved_zero],
+    },
+    {'bits': 3, 'name': 'Expect',
+        'r': [{0: None}],
+        'w': [_reserved_zero],
+    },
+    {'bits': 2, 'name': 'selfTestDone', 'w': [_reserved_zero]},
+    {'bits': 1, 'name': 'responseRetry',
+        'r': [_reserved_zero],
+        'w': [{1: '1 (resend)', 0: None}],
+    },
+    {'bits': 0, 'name': 'Reserved', 'rw': [_reserved_zero]},
+]
+
+_REG_TPM_I2C_INTERFACE_CAPABILITY = [
+    {'bits': 31, 'name': 'Reserved', 'r': [_reserved_zero]},
+    {'bits': 30, 'name': 'GT_SR', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 29, 'name': 'TPM_STS.burstCount', 'r': [{1: 'static', 0: 'dyn.'}]},
+    {'bits': (27, 28), 'name': 'i2c_addr', 'r': [{3: 'mutable (prop.)', 1: 'mutable (TCG)', 0: 'fixed', None: "<undefined>"}]},
+    {'bits': (25, 26), 'name': 'localities', 'r': [{2: '[0-255]', 1: '[0-4]', 0: '[0]', None: "<undefined>"}]},
+    {'bits': 24, 'name': 'HS', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 23, 'name': 'Fm+', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 22, 'name': 'Fm', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 21, 'name': 'Sm', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 20, 'name': 'GT_RR', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 19, 'name': 'GT_RW', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 18, 'name': 'GT_WR', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': 17, 'name': 'GT_WW', 'r': [{1: 'y', 0: 'n'}]},
+    {'bits': (9, 16), 'name': 'GT', 'r': []},
+    {'bits': (7, 8), 'name': 'family', 'r': [{0: '1.2', 1: '2.0', None: '<undefined>'}]},
+    {'bits': (4, 6), 'name': 'vers_i', 'r': [{0: 'TCG', None: '<undefined>'}]},
+    {'bits': (0, 3), 'name': 'type_i', 'r': [{2: 'FIFO'}]},
+]
+
+# TCG TPM Vendor ID Registry
+# Version 1.01 Revision 1.00 18th October 2017
+_TPM_VENDOR_IDS = {
+    0x1022: 'AMD',
+    0x1114: 'Atmel',
+    0x14E4: 'Broadcom',
+    0x1590: 'HPE',
+    0x1014: 'IBM',
+    0x15D1: 'Infineon',
+    0x8086: 'Intel',
+    0x17AA: 'Lenovo',
+    0x1414: 'Microsoft',
+    0x100B: 'National Semi',
+    0x1B4E: 'Nationz',
+    0x1011: 'Qualcomm',
+    0x1055: 'SMSC',
+    0x104A: 'STMicroelectronics',
+    0x144D: 'Samsung',
+    0x19FA: 'Sinosun',
+    0x104C: 'Texas Instruments',
+    0x1050: 'Nuvoton Technology',
+    0x232A: 'Fuzhou Rockchip',
+    0x6666: 'Google',
+    None: '<unknown>'
+}
+
+_REG_TPM_DID_VID = [
+    {'bits': (31, 0), 'name': 'TPM_DID_VID_x', 'w': [_reg_read_only], 'r': [None]},
+    {'bits': (31, 16), 'name': 'DID', 'w': [None]},
+    {'bits': (15, 0), 'name': 'VID', 'r': [_TPM_VENDOR_IDS], 'w': [None]},
+]
+
+_REG_TPM_RID = [
+    {'bits': (7, 0), 'name': 'TPM_RID_x', 'w': [_reg_read_only], 'r': [None]},
+    {'bits': (7, 0), 'name': 'VID', 'w': [None]},
+]
+
+_I2C_TPM_REGISTERS = {
+    0x00: ('TPM_LOC_SEL', 1),
+    0x04: ('TPM_ACCESS', 1, _REG_TPM_ACCESS),
+    0x08: ('TPM_INT_ENABLE', 4),
+    0x10: ('TPM_INT_STATUS', 4),
+    0x14: ('TPM_INT_CAPABILITY', 4),
+    0x18: ('TPM_STS', 4, _REG_TPM_STATUS),
+    0x20: ('TPM_HASH_END', 1),
+    0x24: ('TPM_DATA_FIFO', 4),
+    0x28: ('TPM_HASH_START', 1),
+    0x30: ('TPM_I2C_INTERFACE_CAPABILITY', 4, _REG_TPM_I2C_INTERFACE_CAPABILITY),
+    0x38: ('TPM_I2C_DEVICE_ADDRESS', 2),
+    0x40: ('TPM_DATA_CSUM_ENABLE', 1),
+    0x44: ('TPM_DATA_CSUM', 2),
+    0x48: ('TPM_DID_VID', 4, _REG_TPM_DID_VID),
+    0x4C: ('TPM_DID_RID', 1, _REG_TPM_RID),
+}
+
+_SPI_TPM_REGISTERS = {
+    0xD40000: ('TPM_ACCESS_{locality}', 1, _REG_TPM_ACCESS),
+    0xD40008: ('TPM_INT_ENABLE_{locality}', 4),
+    0xD4000c: ('TPM_INT_VECTOR_{locality}', 1),
+    0xD40010: ('TPM_INT_STATUS_{locality}', 4),
+    0xD40014: ('TPM_INTF_CAPABILITY_{locality}', 5),
+    0xD40018: ('TPM_STS_{locality}', 6, _REG_TPM_STATUS),
+    0xD40024: ('TPM_DATA_FIFO_{locality}', 4),
+    0xD40030: ('TPM_INTERFACE_ID_{locality}', 4),
+    0xD40080: ('TPM_XDATA_FIFO_{locality}', 4),
+    0xD40F00: ('TPM_DID_VID_{locality}', 4, _REG_TPM_DID_VID),
+    0xD40F04: ('TPM_RID_{locality}', 1, _REG_TPM_RID),
+    0xD40F90: ('vendor-defined', 0x70),
+}
+
+
+def _bits_mask(bits):
+    ''':param Union[Tuple[int, int], int] bits: tuple of high and low bits (inclusive), or index of a single bit
+    :return int: mask selecting those bits'''
+    if isinstance(bits, int):  # single bit mask
+        bits = (bits, bits)
+    hi_bit, lo_bit = bits
+    hi_mask = (1 << (hi_bit + 1)) - 1
+    lo_mask = (1 << lo_bit) - 1
+    return hi_mask ^ lo_mask
+
+
+def _extract_bits(bits, data):
+    mask = _bits_mask(bits)
+    shift = bits if isinstance(bits, int) else bits[1]
+    return (data & mask) >> shift
+
+
+def decode_register(data, regspec, reading=True):
+    data_bits = len(data) * 8
+    data = int.from_bytes(data, 'little')
+    parts = []
+    for field in regspec:
+        bits = field['bits']
+        bit_lo = bits if isinstance(bits, int) else bits[1]
+        if bit_lo >= data_bits:
+            continue
+        value = _extract_bits(bits, data)
+
+        # specialization for reading/writing, so we can have separate checks/conversions
+        if 'reading' in field and reading:
+            field = dict(field)
+            field.update(field['reading'])
+        elif 'writing' in field and not reading:
+            field = dict(field)
+            field.update(field['writing'])
+
+        pipeline = field.get('rw', [])
+        if reading:
+            pipeline.extend(field.get('r', []))
+        else:
+            pipeline.extend(field.get('w', []))
+
+        # Pipeline - perform steps with the value, e.g. checking/transforming
+        for step in pipeline:
+            if isinstance(step, (type(None), str)):  # short form to drop a value
+                value = None
+            elif isinstance(step, dict):  # translation table
+                value = step.get(value, step.get(None, value))
+            else:  # conversion function
+                try:
+                    value = step(value=value, field=field, reading=reading)
+                except TypeError:
+                    print("\n\nTYPE ERROR\n\n", value, field, reading, step)
+
+        if value is not None:
+            name = field['name']
+            format_str = field.get('format', '{name}={value}')
+            format_str = {  # short forms
+                'X': '{name}={value:X}',
+                'B': '{name}={value:b}',
+                'N': '{name}',
+                'V': '{value}',
+            }.get(format_str, format_str)
+            part = format_str.format(name=name, value=value)
+            parts.append(part)
+    return '{' + ','.join(parts) + '}'
+
+
+def xfer_annotations(xfer):
+    if xfer.addr & 0xffff0000 == 0x00d40000:
+        reg = xfer.addr & 0x0fff
+        reg_name, reg_size, *reg_extra = _SPI_TPM_REGISTERS.get(xfer.addr, ('{xfer_addr:08X} (resvd)'.format(xfer_addr=xfer.addr), 0))
+        locality = (xfer.addr & 0xf000) >> 12
+        reg_name = reg_name.format(locality=locality)
+    else:
+        reg = xfer.addr & 0xff
+        reg_name, reg_size, *reg_extra = _I2C_TPM_REGISTERS.get(xfer.addr, ('{xfer_addr:08X} (resvd)'.format(xfer_addr=xfer.addr), 0))
+    annotations = [reg_name + '=' + binascii.hexlify(xfer.data).decode()]
+    if len(reg_extra) > 0:
+        annotations.insert(0, reg_name + '=' + decode_register(xfer.data, reg_extra[0], xfer.reading) + "(" + str(len(xfer.data)) + "b)")
+    return annotations

--- a/decoders/tpm_tis_i2c/__init__.py
+++ b/decoders/tpm_tis_i2c/__init__.py
@@ -1,0 +1,24 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2022 Johannes Holland <johannes.holland@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+'''
+Decode the TPM TIS transactions contained in an I2C signal
+'''
+
+from .pd import Decoder

--- a/decoders/tpm_tis_i2c/pd.py
+++ b/decoders/tpm_tis_i2c/pd.py
@@ -1,0 +1,78 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+# Copyright (C) 2022 Johannes Holland <johannes.holland@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+'''
+Decode the TPM TIS transactions contained in an I2C signal.
+References: [tis] TCG PC Client Platform TPM Profile (PTP) Specification https://trustedcomputinggroup.org/wp-content/uploads/PC-Client-Specific-Platform-TPM-Profile-for-TPM-2p0-v1p05p_r14_pub.pdf
+'''
+
+import sigrokdecode as srd
+
+from . import tpm_tis_i2c
+
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'tpm_tis_i2c'
+    name = 'TPM TIS 2.0 I2C'
+    longname = 'Trusted Platform Module Interface (TIS 2.0) over Inter-Integrated Circuit Bus'
+    desc = 'Trusted Platform Module Interface (TIS 2.0) over Inter-Integrated Circuit Bus'
+    license = 'gplv3+'
+    inputs = ['i2c']
+    outputs = ['tpm-tis']
+    tags = ['TPM']
+    annotations = tpm_tis_i2c.ANNOTATIONS
+    annotation_rows = (
+        ('protocol', 'Protocol', (tpm_tis_i2c.ANN_ADDRESS, tpm_tis_i2c.ANN_DATA_READ, tpm_tis_i2c.ANN_DATA_WRITE)),
+        ('transactions', 'Transactions', (tpm_tis_i2c.ANN_TRANSACTION,)),
+        ('warnings', 'Warnings', (tpm_tis_i2c.ANN_WARNING,)),
+    )
+
+    def __init__(self, **kwargs):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+        self.out_py = self.register(srd.OUTPUT_PYTHON)
+
+    def reset(self):
+        self._decoder = None
+
+    def _reset_decoder(self):
+        self._decoder = tpm_tis_i2c.decoder(self.out_ann, self.out_py)
+        ann = self._decoder.send(None)
+        while ann is not None:
+            self.put(*ann)
+            ann = self._decoder.send(None)
+
+    def decode(self, ss, es, data):
+        ptype, pdata = data
+        if ptype == 'BITS':
+            return
+
+        if self._decoder is None:
+            self._reset_decoder()
+        try:
+            ann = self._decoder.send((ss, es, ptype, pdata))
+            while ann is not None:
+                self.put(*ann)
+                ann = self._decoder.send(None)
+        except (StopIteration, ValueError):
+            self._decoder = None

--- a/decoders/tpm_tis_i2c/tpm_tis_i2c.py
+++ b/decoders/tpm_tis_i2c/tpm_tis_i2c.py
@@ -1,0 +1,156 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2022 Johannes Holland <johannes.holland@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+import binascii
+
+from collections import namedtuple
+
+
+ANNOTATIONS = (
+    ('address', 'Address'),
+    ('data_read', 'Data (Read)'),
+    ('data_write', 'Data (Write)'),
+    ('transaction', 'Transaction'),
+    ('warning', 'Warning'),
+)
+ANN_ADDRESS = 0
+ANN_DATA_READ = 1
+ANN_DATA_WRITE = 2
+ANN_TRANSACTION = 3
+ANN_WARNING = 4
+
+Transaction = namedtuple('Transaction', ['reading', 'addr', 'data'])
+
+def _finish_annotations(annotations):
+    '''Depending on the amount of data read/written, sometimes the data-less formats (e.g. 'write 11 bytes') end up longer than the ones with data ('write 1234').
+    In those cases, we remove them, because if we have the space to show the data, we don't want sigrok to pick the longer but less informative string.
+    Assume :param annotations: is sorted by preference, and throw out any longer annotations following shorter ones.'''
+    finished = [annotations[0]]
+    for ann in annotations[1:]:
+        if len(ann) < len(finished[-1]):
+            finished.append(ann)
+    return finished
+
+
+def decoder(out_ann, out_py):
+    '''A coroutine. Send in (ss, es, ptype, pdata) tuples.
+    Yields None when it wants data, and (ss, es, annotation, data) tuples when it has annotations.'''
+    transition_ss = 0
+
+    def get_next(ptype_exp=None, warn_ss=None, warn=True, raises_error=True):
+        '''A coroutine. Send in a (ss, es, ptype, pdata) tuple.
+        Yields None when it wants data, and a tuple (ss, es, annotation, data) when a warning must be shown.
+        Returns (ss, es, ptype, pdata) on success or yields a warning annotation and raises ValueError() otherwise.'''
+        if warn_ss is None:
+            warn_ss = transition_ss
+        if isinstance(ptype_exp, str):
+            ptype_exp = [ptype_exp]
+
+        ss, es, ptype, pdata = yield None
+
+        error = ptype_exp is not None and ptype not in ptype_exp
+        if error:
+            warn_msg = 'got I2C {ptype} but expected one of {ptype_exp}'.format(ptype=ptype, ptype_exp=ptype_exp)
+            if warn:
+                yield (warn_ss, es, out_ann, [ANN_WARNING, [warn_msg]])
+            if raises_error:
+                raise ValueError(warn_msg)
+        return ss, es, ptype, pdata
+
+    # Transition start
+    transition_ss, _, _, _ = yield from get_next("START", warn=False)
+    addr_ss, _, _, _i2c_addr = yield from get_next("ADDRESS WRITE", warn=False)
+    yield from get_next("ACK")
+
+    # TIS register address
+    data_ss, _, _, addr = yield from get_next("DATA WRITE")
+    _, data_es, _, _ = yield from get_next("ACK")
+
+    yield (addr_ss, data_es, out_ann, [ANN_ADDRESS, _finish_annotations([
+        '{addr:02X}'.format(addr=addr),
+    ])])
+
+    # TIS read or write
+    ss, es, ptype, pdata = yield from get_next(('START REPEAT', 'STOP', 'DATA WRITE'))
+    if ptype in ('START REPEAT', 'STOP'):
+        # TIS data read
+        if ptype == 'STOP':
+            yield from get_next("START")
+
+        data_ss, _, _, _i2c_addr = yield from get_next("ADDRESS READ")
+        yield from get_next("ACK")
+
+        # multiple DATA READ until master NACKs
+        data = []
+        data_es = None
+        while True:
+            _, _, _, data_byte = yield from get_next("DATA READ")
+            _, es, ptype, _ = yield from get_next(("ACK", "NACK"))
+
+            data_es = es
+            data.append(data_byte)
+
+            if ptype == "NACK":
+                break
+        data = bytes(data)
+
+        data_annotations = [
+            '{data}'.format(data=binascii.hexlify(data).upper().decode()),
+            '[{data_len} bytes]'.format(data_len=len(data)),
+        ]
+        yield (data_ss, data_es, out_ann, [ANN_DATA_READ, _finish_annotations(data_annotations)])
+
+        yield from get_next("STOP")
+
+        reading = True
+
+    else:
+        # TIS data write
+        # multiple DATA WRITEs until STOP
+        data = []
+        data_ss, data_es = None, None
+        while ptype == 'DATA WRITE':
+            data_byte = pdata
+            # ACK
+            _, es, _, _ = yield from get_next("ACK")
+
+            data_ss = data_ss or ss
+            data_es = es
+            data.append(data_byte)
+
+            ss, _, ptype, pdata = yield from get_next(('DATA WRITE', 'STOP'))
+        data = bytes(data)
+
+        data_annotations = [
+            '{data}'.format(data=binascii.hexlify(data).upper().decode()),
+            '[{data_len} bytes]'.format(data_len=len(data)),
+        ]
+        yield (data_ss, data_es, out_ann, [ANN_DATA_WRITE, _finish_annotations(data_annotations)])
+
+        reading = False
+
+    # Transaction annotation
+    transaction_op = '->' if reading else '<-'
+    transaction_op_long = 'Read' if reading else 'Write'
+    transaction_annotations = ['{addr:02X} {transaction_op} '.format(addr=addr, transaction_op=transaction_op) + data_ann for data_ann in data_annotations] + [
+        '{transaction_op_long} {addr:02X}'.format(transaction_op_long=transaction_op_long, addr=addr),
+        '{transaction_op_long[0]} {addr:02X}'.format(transaction_op_long=transaction_op_long, addr=addr),
+    ]
+    yield (addr_ss, data_es, out_ann, [ANN_TRANSACTION, _finish_annotations(transaction_annotations)])
+    yield (addr_ss, data_es, out_py, ['TRANSACTION', Transaction(reading, addr, data)])

--- a/decoders/tpm_tis_spi/__init__.py
+++ b/decoders/tpm_tis_spi/__init__.py
@@ -1,0 +1,24 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+'''
+Decode the TPM TIS transactions contained in an SPI signal
+'''
+
+from .pd import Decoder

--- a/decoders/tpm_tis_spi/pd.py
+++ b/decoders/tpm_tis_spi/pd.py
@@ -1,0 +1,77 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+'''
+Decode the TPM TIS transactions contained in an SPI signal.
+References: [tis] TCG PC Client Platform TPM Profile (PTP) Specification https://trustedcomputinggroup.org/wp-content/uploads/TCG_PC_Client_Platform_TPM_Profile_PTP_2.0_r1.03_v22.pdf
+'''
+
+import sigrokdecode as srd
+
+from . import tpm_tis_spi
+
+
+class Decoder(srd.Decoder):
+    api_version = 3
+    id = 'tpm_tis_spi'
+    name = 'TPM TIS 2.0 SPI'
+    longname = 'Trusted Platform Module Interface (TIS 2.0) over Serial Peripheral Bus'
+    desc = 'Trusted Platform Module Interface (TIS 2.0) over Serial Peripheral Bus'
+    license = 'gplv3+'
+    inputs = ['spi']
+    outputs = ['tpm-tis']
+    tags = ['TPM']
+    annotations = tpm_tis_spi.ANNOTATIONS
+    annotation_rows = (
+        ('protocol', 'Protocol', (tpm_tis_spi.ANN_RW_LENGTH, tpm_tis_spi.ANN_ADDRESS, tpm_tis_spi.ANN_WAIT_STATE, tpm_tis_spi.ANN_DATA)),
+        ('transactions', 'Transactions', (tpm_tis_spi.ANN_TRANSACTION,)),
+        ('warnings', 'Warnings', (tpm_tis_spi.ANN_WARNING,)),
+    )
+
+    def __init__(self, **kwargs):
+        self.reset()
+
+    def start(self):
+        self.out_ann = self.register(srd.OUTPUT_ANN)
+        self.out_py = self.register(srd.OUTPUT_PYTHON)
+
+    def reset(self):
+        self._decoder = None
+
+    def _reset_decoder(self):
+        self._decoder = iter(tpm_tis_spi.decoder(self.out_ann, self.out_py))
+        ann = self._decoder.send(None)
+        while ann is not None:
+            self.put(*ann)
+            ann = self._decoder.send(None)
+
+    def decode(self, ss, es, data):
+        ptype, mosi, miso = data
+        if ptype != 'DATA':
+            return
+
+        if self._decoder is None:
+            self._reset_decoder()
+        try:
+            ann = self._decoder.send((ss, es, mosi, miso))
+            while ann is not None:
+                self.put(*ann)
+                ann = self._decoder.send(None)
+        except StopIteration:
+            self._decoder = None

--- a/decoders/tpm_tis_spi/tpm_tis_spi.py
+++ b/decoders/tpm_tis_spi/tpm_tis_spi.py
@@ -1,0 +1,125 @@
+#
+# This file is part of the libsigrokdecode project.
+#
+# Copyright (C) 2020-2021 Tobias Peter <tobias.peter@infineon.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>.
+#
+
+import binascii
+
+from collections import namedtuple
+
+
+ANNOTATIONS = (
+    ('rw-length', 'RW/Length'),
+    ('address', 'Address'),
+    ('wait-state', 'Wait State'),
+    ('data', 'Data'),
+    ('transaction', 'Transaction'),
+    ('warning', 'Warning'),
+)
+ANN_RW_LENGTH = 0
+ANN_ADDRESS = 1
+ANN_WAIT_STATE = 2
+ANN_DATA = 3
+ANN_TRANSACTION = 4
+ANN_WARNING = 5
+
+Transaction = namedtuple('Transaction', ['reading', 'addr', 'data'])
+
+
+def _finish_annotations(annotations):
+    '''Depending on the amount of data read/written, sometimes the data-less formats (e.g. 'write 11 bytes') end up longer than the ones with data ('write 1234').
+    In those cases, we remove them, because if we have the space to show the data, we don't want sigrok to pick the longer but less informative string.
+    Assume :param annotations: is sorted by preference, and throw out any longer annotations following shorter ones.'''
+    finished = [annotations[0]]
+    for ann in annotations[1:]:
+        if len(ann) < len(finished[-1]):
+            finished.append(ann)
+    return finished
+
+
+def _warn_duplex(ss, es, ann, peer_byte):
+    if peer_byte != 0:
+        yield (ss, es, ann, [ANN_WARNING, ['unexpected duplex operation']])
+
+
+def decoder(out_ann, out_py):
+    '''A coroutine. Send in (ss, es, mosi_byte, miso_byte) tuples.
+    Yields None when it wants data, and (ss, es, annotation, data) tuples when it has annotations.'''
+    # Read/Write and Length Bit
+    rwl_ss, rwl_es, rwl_mosi, rwl_miso = yield None
+    yield from _warn_duplex(rwl_ss, rwl_es, out_ann, rwl_miso)
+    reading = rwl_mosi & 0x80 == 0x80
+    length = (rwl_mosi & 0x7f) + 1
+    rw_char = 'R' if reading else 'W'
+    yield (rwl_ss, rwl_es, out_ann, [ANN_RW_LENGTH, ['{rw_char} {length:d}'.format(rw_char=rw_char, length=length), '{rw_char}{length:d}'.format(rw_char=rw_char, length=length)]])
+
+    # Address
+    addr2_ss, addr2_es, addr2, addr2_miso = yield None
+    addr1_ss, addr1_es, addr1, addr1_miso = yield None
+    addr0_ss, addr0_es, addr0, addr0_miso = yield None
+    yield from _warn_duplex(addr2_ss, addr2_es, out_ann, addr2_miso)
+    yield from _warn_duplex(addr1_ss, addr1_es, out_ann, addr1_miso)
+    yield from _warn_duplex(addr0_ss, addr0_es, out_ann, addr0_miso if addr0_miso != 1 else 0)  # miso high at end of addr0 is allowed
+    wait_state = (addr0_miso == 0)
+
+    addr_short = addr1 << 8 | addr0
+    addr = addr2 << 16 | addr_short
+    yield (addr2_ss, addr0_es, out_ann, [ANN_ADDRESS, _finish_annotations([
+        '{addr:06X}'.format(addr=addr),
+        '{addr:X}'.format(addr=addr),
+        '{addr_short:04X}'.format(addr_short=addr_short),
+        '{addr_short:X}'.format(addr_short=addr_short),
+    ])])
+
+    # Collect Data
+    data = []
+    data_ss, data_es = None, None
+    for _ in range(length):
+        ss, es, mosi_byte, miso_byte = yield None
+        if data_ss is None:
+            data_ss = ss
+        data_es = es
+
+        if reading:
+            cross_byte, data_byte = mosi_byte, miso_byte
+        else:
+            data_byte, cross_byte = mosi_byte, miso_byte
+
+        yield from _warn_duplex(ss, es, out_ann, cross_byte)
+        data.append(data_byte)
+    data = bytes(data)
+
+    # Wait State
+    if wait_state:
+        yield (addr0_es, data_ss, out_ann, [ANN_WAIT_STATE, ['wait state', 'wait', 'w', '']])
+
+    # Data annotation
+    data_annotations = [
+        binascii.hexlify(data).upper().decode(),
+        '[{data_len} bytes]'.format(data_len=len(data))
+    ]
+    yield (data_ss, data_es, out_ann, [ANN_DATA, _finish_annotations(data_annotations)])
+
+    # Transaction annotation
+    transaction_op = '->' if reading else '<-'
+    transaction_op_long = 'Read' if reading else 'Write'
+    transaction_annotations = ['{addr:X} {transaction_op} '.format(addr=addr, transaction_op=transaction_op) + data_ann for data_ann in data_annotations] + [
+        '{transaction_op_long} {addr:X}'.format(transaction_op_long=transaction_op_long, addr=addr),
+        '{transaction_op_long[0]} {addr:X}'.format(transaction_op_long=transaction_op_long, addr=addr),
+    ]
+    yield (rwl_ss, data_es, out_ann, [ANN_TRANSACTION, _finish_annotations(transaction_annotations)])
+    yield (rwl_ss, data_es, out_py, ['TRANSACTION', Transaction(reading, addr, data)])


### PR DESCRIPTION
Add decoders for the communication stack between the **Trusted Platform Module (TPM)** and a host machine. Included are three decoders, `tpm_tis_i2c` and `tpm_tis_spi` which implement register access and `tpm_fifo_tis` which implements the so-called (TPM Interface Specification) TIS protocol on top of that.

The TPM commands and responses are not yet implemented, the `tpm_fifo_tis` decoder merely decodes command names and response error codes.

|Protocol layer / Decoder name| Description | Specification |
|---|---|---|
|_not included in this PR_| TPM commands and responses (via the FIFO register) | [TPM 2.0 Library Specification](https://trustedcomputinggroup.org/resource/tpm-library-specification/) |
|`tpm_fifo_tis`| Stateful protocol based on register writes/reads | [TCG PC Client Platform TPM Profile (PTP) Specification](https://trustedcomputinggroup.org/resource/pc-client-platform-tpm-profile-ptp-specification/) |
|`tpm_tis_i2c`, `tpm_tis_spi`| Register access based on I2C and SPI (as seperate decoders) | [TCG PC Client Platform TPM Profile (PTP) Specification](https://trustedcomputinggroup.org/resource/pc-client-platform-tpm-profile-ptp-specification/) |
|spi, i2c|  |  |