### PR TITLE
Adf435x: Fix decoder triggering on wrong CS edge

### DIFF
--- a/decoders/adf435x/pd.py
+++ b/decoders/adf435x/pd.py
@@ -113,7 +113,6 @@ class Decoder(srd.Decoder):
 
     def reset(self):
         self.bits = []
-        self.packet_start = 0
 
     def start(self):
         self.out_ann = self.register(srd.OUTPUT_ANN)
@@ -129,28 +128,22 @@ class Decoder(srd.Decoder):
         return val
 
     def decode(self, ss, es, data):
-
         ptype, _, _ = data
 
-        if ptype == 'CS-CHANGE':
-            _, cs_before, cs_after = data
-            if cs_before == 1:
-                if len(self.bits) == 32:
-                    reg_value, reg_pos = self.decode_bits(0, 3)
-                    self.put(reg_pos[0], reg_pos[1], self.out_ann, [ANN_REG,
-                        ['Register: %d' % reg_value, 'Reg: %d' % reg_value,
-                         '[%d]' % reg_value]])
-                    if reg_value < len(regs):
-                        field_descs = regs[reg_value]
-                        for field_desc in field_descs:
-                            field = self.decode_field(*field_desc)
-                else:
-                    error = "Frame error: Wrong number of bits: got %d expected 32" % len(self.bits)
-                    self.put(self.packet_start, es, self.out_ann, [ANN_WARN, [error, 'Frame error']])
-                self.bits = []
+        if ptype == 'TRANSFER':
+            if len(self.bits) == 32:
+                reg_value, reg_pos = self.decode_bits(0, 3)
+                self.put(reg_pos[0], reg_pos[1], self.out_ann, [ANN_REG,
+                    ['Register: %d' % reg_value, 'Reg: %d' % reg_value,
+                     '[%d]' % reg_value]])
+                if reg_value < len(regs):
+                    field_descs = regs[reg_value]
+                    for field_desc in field_descs:
+                        field = self.decode_field(*field_desc)
             else:
-                # Start of a new register write packet
-                self.packet_start = ss
+                error = "Frame error: Wrong number of bits: got %d expected 32" % len(self.bits)
+                self.put(self.packet_start, es, self.out_ann, [ANN_WARN, [error, 'Frame error']])
+            self.bits = []
 
         if ptype == 'BITS':
             _, mosi_bits, miso_bits = data

--- a/decoders/adf435x/pd.py
+++ b/decoders/adf435x/pd.py
@@ -126,10 +126,11 @@ class Decoder(srd.Decoder):
 
     def decode(self, ss, es, data):
 
-        ptype, data1, data2 = data
+        ptype, _, _ = data
 
         if ptype == 'CS-CHANGE':
-            if data1 == 1:
+            _, cs_before, cs_after = data
+            if cs_before == 1:
                 if len(self.bits) == 32:
                     reg_value, reg_pos = self.decode_bits(0, 3)
                     self.put(reg_pos[0], reg_pos[1], self.out_ann, [ANN_REG,
@@ -141,4 +142,5 @@ class Decoder(srd.Decoder):
                             field = self.decode_field(*field_desc)
                 self.bits = []
         if ptype == 'BITS':
-            self.bits = data1 + self.bits
+            _, mosi_bits, miso_bits = data
+            self.bits = mosi_bits + self.bits


### PR DESCRIPTION
The current adf435x decoder triggers decoding on falling CS edge. The datasheet says new values are latched in on rising edge. This leads to the last frame not getting decoded on some captures when more SPI-like communication is used instead of shift-register-like communication.

This patch set cleans up some confusing variable names, adds a warning on frame errors where wrong number of bits are clocked in and finally moves the decoding logic to use the underlying SPI decoder's transfer events.

This fixes bug https://sigrok.org/bugzilla/show_bug.cgi?id=1814