### PR TITLE
fix lpc clock issue

### DIFF
--- a/decoders/lpc/pd.py
+++ b/decoders/lpc/pd.py
@@ -331,6 +331,7 @@ class Decoder(srd.Decoder):
             if not (self.oldlclk == 0 and lclk == 1):
                 self.oldlclk = lclk
                 continue
+            self.oldlclk = lclk
 
             # Store LAD[3:0] bit values (one nibble) in local variables.
             # Most (but not all) states need this.


### PR DESCRIPTION
Without this patch, `decode()` doesn't save `oldlclk` unless `lclk` is low. Making the rest of the loop repeat every sample that `lclk` is high, instead of on the rising edge as is defined by the LPC and PCI standards.