### PR TITLE
Allow resetting counter decoder on both edges

### DIFF
--- a/decoders/counter/pd.py
+++ b/decoders/counter/pd.py
@@ -53,7 +53,7 @@ class Decoder(srd.Decoder):
             'values': ('any', 'rising', 'falling')},
         {'id': 'divider', 'desc': 'Count divider (word width)', 'default': 0},
         {'id': 'reset_edge', 'desc': 'Edge which clears counters (reset)',
-            'default': 'falling', 'values': ('rising', 'falling')},
+            'default': 'falling', 'values': ('any', 'rising', 'falling')},
         {'id': 'edge_off', 'desc': 'Edge counter value after start/reset', 'default': 0},
         {'id': 'word_off', 'desc': 'Word counter value after start/reset', 'default': 0},
         {'id': 'dead_cycles', 'desc': 'Ignore this many edges after reset', 'default': 0},


### PR DESCRIPTION
Previously, counter reset could only be performed on the riser OR falling edge. After this change, it is possible to reset it on both.

New
![Pulseview counter reset on both edges](https://github.com/sigrokproject/libsigrokdecode/assets/16807587/eba82a02-baca-479a-b587-4f1b0353cd6f)

Before
![Pulseview counter reset original](https://github.com/sigrokproject/libsigrokdecode/assets/16807587/3d736804-b34b-40b1-baac-800f8402dc82)
