### PR TITLE
Rename rgb_led_ws281x rgb_led_clockless, add lighting tag, and add options for it to decode a wider range of rgb strips

### DIFF
--- a/decoders/rgb_led_clockless/__init__.py
+++ b/decoders/rgb_led_clockless/__init__.py
@@ -18,7 +18,7 @@
 ##
 
 '''
-WS281x RGB LED protocol decoder.
+clockless RGB LED protocol decoder.
 
 Details:
 https://cpldcpu.wordpress.com/2014/01/14/light_ws2812-library-v2-0-part-i-understanding-the-ws2812/

--- a/decoders/rgb_led_clockless/__init__.py
+++ b/decoders/rgb_led_clockless/__init__.py
@@ -19,6 +19,7 @@
 
 '''
 clockless RGB LED protocol decoder.
+Decoder for RGB LED string clockless one-wire protocol (WS2812, WS2812B, APA104, SM16703, SK6812 ).'
 
 Details:
 https://cpldcpu.wordpress.com/2014/01/14/light_ws2812-library-v2-0-part-i-understanding-the-ws2812/

--- a/decoders/rgb_led_clockless/pd.py
+++ b/decoders/rgb_led_clockless/pd.py
@@ -62,13 +62,13 @@ class DecoderError(Exception):
 class Decoder(srd.Decoder):
     api_version = 3
     id = 'rgb_led_ws281x'
-    name = 'RGB LED (WS281x)'
-    longname = 'RGB LED string decoder (WS281x)'
-    desc = 'RGB LED string protocol (WS281x).'
+    name = 'RGB LED (clockless)'
+    longname = 'RGB LED string decoder (clockless)'
+    desc = 'RGB LED string protocol (clockless).'
     license = 'gplv3+'
     inputs = ['logic']
     outputs = []
-    tags = ['Display', 'IC']
+    tags = ['Display', 'Lighting']
     channels = (
         {'id': 'din', 'name': 'DIN', 'desc': 'DIN data line'},
     )

--- a/decoders/rgb_led_spi/pd.py
+++ b/decoders/rgb_led_spi/pd.py
@@ -30,7 +30,7 @@ class Decoder(srd.Decoder):
     license = 'gplv2+'
     inputs = ['spi']
     outputs = []
-    tags = ['Display']
+    tags = ['Display', 'Lighting']
     annotations = (
         ('rgb', 'RGB value'),
     )


### PR DESCRIPTION
Revamp of a lot of the code

- added a new option to specify the LED type (WS281x or SK6812) to resolves timing issues specific to SK6812 LEDs. Code is now more modular and can add other LED types with different timing requirements.
- added option for is_rgbw so white can be applied to any RGB order(might be a problem if any strips have white as any byte other then the 4th)
- moved preprocess options to its own method
- fixed handling of the last bit before the reset by extending its annotation and properly managing the reset timing
- added Lighting tag to it and rgb_led_spi

The decoder was tested with both WS2812b and SK6812 LED strips to confirm the accuracy of timing adjustments and bit handling improvements.