### PR TITLE
Fix: Correct byte order in address representation for 'xx1527' model

### DIFF
--- a/decoders/rc_encode/pd.py
+++ b/decoders/rc_encode/pd.py
@@ -101,7 +101,7 @@ def decode_model(model, bits):
                 addr_valid = 0
 
         if addr_valid == 1:
-            address = 'Address 0x%X %X %X' % (addr & 0xFF, (addr >> 8) & 0xFF, addr >> 16)
+            address = 'Address 0x%X %X %X' % (addr >> 16, (addr >> 8) & 0xFF, addr & 0xFF)
         else:
             address = 'Invalid address as not all bits are 0 or 1'
 


### PR DESCRIPTION
### Summary
This pull request fixes a bug in the `xx1527` model where the address bytes were displayed in the wrong order.

### Problem
The original code incorrectly formats the 24-bit address by reversing the byte order:
```python
address = 'Address 0x%X %X %X' % (addr & 0xFF, (addr >> 8) & 0xFF, addr >> 16)
````

This results in the least significant byte appearing first, which is misleading and inconsistent with common address representations.

### Fix

Replaced the line with:

```python
address = 'Address 0x%X %X %X' % (addr >> 16, (addr >> 8) & 0xFF, addr & 0xFF)
```

This correctly displays the most significant byte first, ensuring the address is shown in standard big-endian order (MSB → LSB).

### Impact

* The address output is now correctly formatted.
* No other functionality is affected.