### PR TITLE
sdcard_sd: Decode commands always as command

### DIFF
--- a/decoders/sdcard_sd/pd.py
+++ b/decoders/sdcard_sd/pd.py
@@ -142,6 +142,11 @@ class Decoder(srd.Decoder):
         self.token.append(Bit(self.samplenum, self.samplenum, cmd_pin))
         if len(self.token) > 0:
             self.token[len(self.token) - 2].es = self.samplenum
+            # check the transmission bit if this is a command
+            if len(self.token) == 2:
+                transmission = self.token[1].bit
+                if transmission:
+                    self.state = St.GET_COMMAND_TOKEN
         if len(self.token) < n:
             return False
         self.token[n - 1].es += self.token[n - 1].ss - self.token[n - 2].ss


### PR DESCRIPTION
The SD card decoder predicts always the next token type from the current token type. This is working if the SD card is responding as expected. But if the card is not responding, the prediction is wrong. A second command token is decoded as a response token. 

See example trace file. [SD-card-init-001.zip](https://github.com/user-attachments/files/24038547/SD-card-init-001.zip)

To fix this behavior the decoder state is set to St.GET_COMMAND_TOKEN, if the current token is a command token.
