### PR TITLE
CAN: Fix CRC field decoding for CAN-FD

### DIFF
--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -64,10 +64,11 @@ class Decoder(srd.Decoder):
         ('stuff-bit', 'Stuff bit'),
         ('warning', 'Warning'),
         ('bit', 'Bit'),
+        ('sbc', 'Stuff bit count')
     )
     annotation_rows = (
         ('bits', 'Bits', (15, 17)),
-        ('fields', 'Fields', tuple(range(15))),
+        ('fields', 'Fields', tuple(range(15)) + (18,)),
         ('warnings', 'Warnings', (16,)),
     )
 
@@ -97,9 +98,9 @@ class Decoder(srd.Decoder):
 
         if self.fd:
             if dlc2len(self.dlc) < 16:
-                self.crc_len = 21 # 17 + SBC bits
+                self.crc_len = 17
             else:
-                self.crc_len = 25 # 21 + SBC bits
+                self.crc_len = 21
         else:
             self.crc_len = 15
 
@@ -188,7 +189,7 @@ class Decoder(srd.Decoder):
 
         # Bit stuffing is not applied to the CRC delimiter, ACK field,
         # or End-of-Frame (EOF) field:
-        if cur_bit > self.last_databit + self.crc_len:
+        if cur_bit > self.crc_start + self.crc_len - 1:
             self.last_bit_was_stuff_bit = False
             return False
 
@@ -223,22 +224,28 @@ class Decoder(srd.Decoder):
     # Returns True if the frame ended (EOF), False otherwise.
     def decode_frame_end(self, can_rx, bitnum):
 
-        # Remember start of CRC sequence (see below).
+        # Remember start of Non-FD CRC sequence or FD-SBC field (see below).
         if bitnum == (self.last_databit + 1):
+            self.ss_block = self.samplenum
+        elif self.fd and bitnum == (self.last_databit + 4):
+            # SBC field
+            x = self.last_databit + 1
+            sbc_bits = self.bits[x:x + self.last_databit + 4]
+            sbc = bitpack_msb(sbc_bits)
+
+            self.putb([18, ['Raw stuff bit count: %d' % sbc,
+                            'rSBC: %d' % sbc, 'SBC']])
+
+        # Remember start of FD-CRC sequence (see below).
+        elif self.fd and bitnum == (self.last_databit + 4 + 1):
             self.ss_block = self.samplenum
 
         # CRC sequence (15 bits, 17 bits or 21 bits)
-        elif bitnum == (self.last_databit + self.crc_len):
-            if self.fd:
-                if dlc2len(self.dlc) < 16:
-                    crc_type = "CRC-17"
-                else:
-                    crc_type = "CRC-21"
-            else:
-                crc_type = "CRC-15"
-
-            x = self.last_databit + 1
+        elif bitnum == (self.crc_start - 1 + self.crc_len):
+            x = self.crc_start
             crc_bits = self.bits[x:x + self.crc_len + 1]
+
+            crc_type = "CRC-%d" % self.crc_len
             self.crc = bitpack_msb(crc_bits)
             self.putb([11, ['%s sequence: 0x%04x' % (crc_type, self.crc),
                             '%s: 0x%04x' % (crc_type, self.crc), '%s' % crc_type]])
@@ -246,7 +253,7 @@ class Decoder(srd.Decoder):
                 self.putb([16, ['CRC is invalid']])
 
         # CRC delimiter bit (recessive)
-        elif bitnum == (self.last_databit + self.crc_len + 1):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 1):
             self.putx([12, ['CRC delimiter: %d' % can_rx,
                             'CRC d: %d' % can_rx, 'CRC d']])
             if can_rx != 1:
@@ -256,23 +263,23 @@ class Decoder(srd.Decoder):
                 self.set_nominal_bitrate()
 
         # ACK slot bit (dominant: ACK, recessive: NACK)
-        elif bitnum == (self.last_databit + self.crc_len + 2):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 2):
             ack = 'ACK' if can_rx == 0 else 'NACK'
             self.putx([13, ['ACK slot: %s' % ack, 'ACK s: %s' % ack, 'ACK s']])
 
         # ACK delimiter bit (recessive)
-        elif bitnum == (self.last_databit + self.crc_len + 3):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 3):
             self.putx([14, ['ACK delimiter: %d' % can_rx,
                             'ACK d: %d' % can_rx, 'ACK d']])
             if can_rx != 1:
                 self.putx([16, ['ACK delimiter must be a recessive bit']])
 
         # Remember start of EOF (see below).
-        elif bitnum == (self.last_databit + self.crc_len + 4):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 4):
             self.ss_block = self.samplenum
 
         # End of frame (EOF), 7 recessive bits
-        elif bitnum == (self.last_databit + self.crc_len + 10):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 3 + 7):
             self.putb([2, ['End of frame', 'EOF', 'E']])
             if self.rawbits[-7:] != [1, 1, 1, 1, 1, 1, 1]:
                 self.putb([16, ['End of frame (EOF) must be 7 recessive bits']])

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -220,6 +220,15 @@ class Decoder(srd.Decoder):
         self.last_bit_was_stuff_bit = True
         return True
 
+    def is_valid_parity(self, num, given_parity_bit):
+        calculated_parity_bit = 0
+
+        while num:
+            calculated_parity_bit ^= num & 1
+            num >>= 1
+
+        return calculated_parity_bit == given_parity_bit
+
     def is_valid_crc(self, crc_bits):
         return True # TODO
 
@@ -243,7 +252,12 @@ class Decoder(srd.Decoder):
             sbc_bits = self.bits[x:x + self.last_databit + 4]
             p_gray_sbc = bitpack_msb(sbc_bits)
 
+            parity = p_gray_sbc & 1
             gray_sbc = p_gray_sbc >> 1
+
+            if not self.is_valid_parity(gray_sbc, parity):
+                self.putb([16, ['Parity is invalid']])
+
             sbc = gray2num(gray_sbc) # Number of stuff bits modulo 8
 
             self.putb([18, ['Stuff bit count: %d' % sbc,

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -140,6 +140,7 @@ class Decoder(srd.Decoder):
         self.bits = [] # Only actual CAN frame bits (no stuff bits)
         self.curbit = 0 # Current bit of CAN frame (bit 0 == SOF)
         self.last_databit = 999 # Positive value that bitnum+x will never match
+        self.crc_start = 999
         self.ss_block = None
         self.ss_bit12 = None
         self.ss_bit32 = None
@@ -332,6 +333,11 @@ class Decoder(srd.Decoder):
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)
+            self.crc_start = self.last_databit + 1
+
+            if self.fd:
+                self.crc_start += 4 # Skip SBC field
+
             if self.dlc > 8 and not self.fd:
                 self.putb([16, ['Data length code (DLC) > 8 is not allowed']])
 
@@ -434,6 +440,10 @@ class Decoder(srd.Decoder):
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)
+            self.crc_start = self.last_databit + 1
+
+            if self.fd:
+                self.crc_start += 4 # Skip SBC field
 
         # Remember all databyte bits, except the very last one.
         elif bitnum in range(self.dlc_start + 4, self.last_databit):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -27,6 +27,16 @@ class SamplerateError(Exception):
 def dlc2len(dlc):
     return [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64][dlc]
 
+def gray2num(gray_code):
+    num = gray_code
+    mask = gray_code
+
+    while mask:
+        mask >>= 1
+        num ^= mask
+
+    return num
+
 class Decoder(srd.Decoder):
     api_version = 3
     id = 'can'
@@ -231,10 +241,13 @@ class Decoder(srd.Decoder):
             # SBC field
             x = self.last_databit + 1
             sbc_bits = self.bits[x:x + self.last_databit + 4]
-            sbc = bitpack_msb(sbc_bits)
+            p_gray_sbc = bitpack_msb(sbc_bits)
 
-            self.putb([18, ['Raw stuff bit count: %d' % sbc,
-                            'rSBC: %d' % sbc, 'SBC']])
+            gray_sbc = p_gray_sbc >> 1
+            sbc = gray2num(gray_sbc) # Number of stuff bits modulo 8
+
+            self.putb([18, ['Stuff bit count: %d' % sbc,
+                            'SBC: %d' % sbc, 'SBC']])
 
         # Remember start of FD-CRC sequence (see below).
         elif self.fd and bitnum == (self.last_databit + 4 + 1):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -92,6 +92,17 @@ class Decoder(srd.Decoder):
     def set_fast_bitrate(self):
         self.set_bit_rate(self.options['fast_bitrate'])
 
+    def set_dlc_and_crc_len(self, dlc):
+        self.dlc = dlc
+
+        if self.fd:
+            if dlc2len(self.dlc) < 16:
+                self.crc_len = 27 # 17 + SBC + stuff bits
+            else:
+                self.crc_len = 32 # 21 + SBC + stuff bits
+        else:
+            self.crc_len = 15
+
     def metadata(self, key, value):
         if key == srd.SRD_CONF_SAMPLERATE:
             self.samplerate = value
@@ -185,13 +196,6 @@ class Decoder(srd.Decoder):
         # Remember start of CRC sequence (see below).
         if bitnum == (self.last_databit + 1):
             self.ss_block = self.samplenum
-            if self.fd:
-                if dlc2len(self.dlc) < 16:
-                    self.crc_len = 27 # 17 + SBC + stuff bits
-                else:
-                    self.crc_len = 32 # 21 + SBC + stuff bits
-            else:
-                self.crc_len = 15
 
         # CRC sequence (15 bits, 17 bits or 21 bits)
         elif bitnum == (self.last_databit + self.crc_len):
@@ -295,7 +299,7 @@ class Decoder(srd.Decoder):
 
         # Bits 15-18: Data length code (DLC), in number of bytes (0-8).
         elif bitnum == self.dlc_start + 3:
-            self.dlc = bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4])
+            self.set_dlc_and_crc_len(bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4]))
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)
@@ -397,7 +401,7 @@ class Decoder(srd.Decoder):
 
         # Bits 35-38: Data length code (DLC), in number of bytes (0-8).
         elif bitnum == self.dlc_start + 3:
-            self.dlc = bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4])
+            self.set_dlc_and_crc_len(bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4]))
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -97,9 +97,9 @@ class Decoder(srd.Decoder):
 
         if self.fd:
             if dlc2len(self.dlc) < 16:
-                self.crc_len = 27 # 17 + SBC + stuff bits
+                self.crc_len = 21 # 17 + SBC bits
             else:
-                self.crc_len = 32 # 21 + SBC + stuff bits
+                self.crc_len = 25 # 21 + SBC bits
         else:
             self.crc_len = 15
 
@@ -148,6 +148,8 @@ class Decoder(srd.Decoder):
         self.rtr_type = None
         self.fd = False
         self.rtr = None
+        self.last_bit_was_stuff_bit = False
+        self.crc_len = 15
 
     # Poor man's clock synchronization. Use signal edges which change to
     # dominant state in rather simple ways. This naive approach is neither
@@ -166,17 +168,44 @@ class Decoder(srd.Decoder):
         return int(samplenum)
 
     def is_stuff_bit(self):
-        # CAN uses NRZ encoding and bit stuffing.
-        # After 5 identical bits, a stuff bit of opposite value is added.
-        # But not in the CRC delimiter, ACK, and end of frame fields.
-        if len(self.bits) > self.last_databit + 17:
+        # CAN uses NRZ encoding (dynamic bit stuffing).
+        # After five consecutive bits of identical value, a stuff bit of the
+        # opposite polarity is inserted.
+        #
+        # In CAN-FD frames, additional fixed bit stuffing is used for the CRC field.
+        # This fixed stuffing begins one bit before the CRC field, regardless of
+        # whether five identical bits have occurred.
+
+        # If a dynamic stuff bit and a fixed stuff bit would be inserted at the
+        # same position, only the fixed stuff bit is inserted. In this case,
+        # only a single stuff bit is inserted:
+        if self.last_bit_was_stuff_bit:
+            self.last_bit_was_stuff_bit = False
             return False
-        last_6_bits = self.rawbits[-6:]
-        if last_6_bits not in ([0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 1, 0]):
+
+        cur_bit = len(self.bits) - 1
+
+        # Bit stuffing is not applied to the CRC delimiter, ACK field,
+        # or End-of-Frame (EOF) field:
+        if cur_bit > self.last_databit + self.crc_len:
+            self.last_bit_was_stuff_bit = False
             return False
+
+        if self.fd and cur_bit > self.last_databit:
+            # Within the CAN-FD CRC field, a fixed stuff bit is inserted after every fourth bit:
+            if (cur_bit - self.last_databit - 1) % 4 != 0:
+                self.last_bit_was_stuff_bit = False
+                return False
+        else:
+            # NRZ dynamic bit stuffing:
+            last_6_bits = self.rawbits[-6:]
+            if last_6_bits not in ([0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 1, 0]):
+                self.last_bit_was_stuff_bit = False
+                return False
 
         # Stuff bit. Keep it in self.rawbits, but drop it from self.bits.
         self.bits.pop() # Drop last bit.
+        self.last_bit_was_stuff_bit = True
         return True
 
     def is_valid_crc(self, crc_bits):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -2,7 +2,7 @@
 ## This file is part of the libsigrokdecode project.
 ##
 ## Copyright (C) 2012-2013 Uwe Hermann <uwe@hermann-uwe.de>
-## Copyright (C) 2019 Stephan Thiele <stephan.thiele@mailbox.org>
+## Copyright (C) 2019-2026 Stephan Thiele <stephan.thiele@mailbox.org>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Currently in CAN decoder, CRC field of CAN-FD is decoded in a wrong way. On classic CAN, CRC-15 field occurs directly after data field. On CAN-FD however, after data field, an SBC field (stuff bit count, modulo 8, gray coded with parity bit) and a CRC-17 or CRC-21 (depending on data length) occur. Additionally, CRC sequence on CAN-FD does not use NRZ bit stuffing but a fixed bit stuffing instead. **Currently on CAN-FD, the SBC field and the stuff bits are part of the CRC value which is incorrect.**

To fix this, in this PR the following steps are done:
- Implement fixed bit stuffing for CAN-FD CRC field
- Split up CAN-FD CRC field into SBC and CRC
- Decode SBC gray code value and check parity bit (annotate warning on invalid parity)

Behaviour of the decoder changes from:

<img width="1829" height="160" alt="image" src="https://github.com/user-attachments/assets/e7b55db8-7fb3-43bf-aabd-0740ea86ec04" />

To:

<img width="1829" height="160" alt="image" src="https://github.com/user-attachments/assets/883d3609-9b32-4be0-bd64-04a634a1ae90" />

Dump used shown in the images is: https://github.com/sigrokproject/sigrok-dumps/blob/master/can/can_fd/arbitrary_traffic/can_fd_std_brs_8.sr

I have made a regression test with [sigrok-test](https://github.com/sigrokproject/sigrok-test) by running `pdtest -r -v can`. Tests of classic CAN dumps pass, except [nmea2000_fuel_flow_gps_snippet](https://github.com/sigrokproject/sigrok-dumps/blob/master/can/nmea2000/lowrance_ep_60r_garmin_gps_17x/nmea2000_fuel_flow_gps_snippet.sr). To me it looks like the sample rate of the recording is too low which leads to invalid values:

<img width="1083" height="217" alt="image" src="https://github.com/user-attachments/assets/30607e14-5c5d-415f-902b-de3b27eae8e7" />

There are only very few samples per bit and the decoder also annotates warnings on some frames. I'd suggest to remove it entirely as, in my opinion, it is not very useful for regression tests in this state.

CAN-FD tests fail as expected in CRC field area.

I have validated some decoded CRC values for CRC-17 and CRC-21 by using PEAK CAN FD Frame Analyzer tool: https://www.peak-system.com/products/software/tools/can-fd-frame-analyzer/

~~I will do another PR in [sigrok-test](https://github.com/sigrokproject/sigrok-test) repo with updated test vectors and link it here once it is created.~~

Edit: PR with the updated test vectors is now created: https://github.com/sigrokproject/sigrok-test/pull/29