### PR TITLE
CAN: Fix CAN-FD bitrate switch

### DIFF
--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -160,6 +160,7 @@ class Decoder(srd.Decoder):
         self.frame_bytes = []
         self.rtr_type = None
         self.fd = False
+        self.brs = False
         self.rtr = None
         self.last_bit_was_stuff_bit = False
         self.crc_len = 15
@@ -507,12 +508,6 @@ class Decoder(srd.Decoder):
         self.rawbits.append(can_rx)
         self.bits.append(can_rx)
 
-        if self.fd and can_rx:
-            if bitnum == 16 and self.frame_type == 'standard' \
-                    or bitnum == 35 and self.frame_type == 'extended':
-                self.dom_edge_seen(force=True)
-                self.set_fd_bitrate()
-
         # If this is a stuff bit, remove it from self.bits and ignore it.
         if self.is_stuff_bit():
             self.putx([15, [str(can_rx)]])
@@ -590,7 +585,18 @@ class Decoder(srd.Decoder):
                 # Wait until we're in the correct bit/sampling position.
                 pos = self.get_sample_point(self.curbit)
                 (can_rx,) = self.wait([{'skip': pos - self.samplenum}, {0: 'f'}])
+
                 if self.matched[1]:
                     self.dom_edge_seen()
                 if self.matched[0]:
+                    if self.fd:
+                        # FD-BRS bit:
+                        if can_rx and (bitnum == 16 and self.frame_type == 'standard'
+                                    or bitnum == 35 and self.frame_type == 'extended'):
+                            self.brs = True if can_rx else False
+
+                            if self.brs:
+                              self.dom_edge_seen(force=True)
+                              self.set_fd_bitrate()
+
                     self.handle_bit(bitnum, can_rx)

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -301,8 +301,19 @@ class Decoder(srd.Decoder):
 
         # CRC delimiter bit (recessive)
         elif bitnum == (self.crc_start - 1 + self.crc_len + 1):
-            self.putx([12, ['CRC delimiter: %d' % can_rx,
-                            'CRC d: %d' % can_rx, 'CRC d']])
+            data = [12, ['CRC delimiter: %d' % can_rx,
+                         'CRC d: %d' % can_rx, 'CRC d']]
+
+            if self.fd and self.brs:
+                from_bitrate = self.options['fd_bitrate']
+                from_spp = self.options['fd_sample_point']
+                to_bitrate = self.options['nominal_bitrate']
+                to_spp = self.options['nominal_sample_point']
+
+                self.putx_brs(from_bitrate, from_spp, to_bitrate, to_spp, data)
+            else:
+                self.putx(data)
+
             if can_rx != 1:
                 self.putx([16, ['CRC delimiter must be a recessive bit']])
 
@@ -369,7 +380,18 @@ class Decoder(srd.Decoder):
             self.putx([7, ['Reserved: %d' % can_rx, 'R0: %d' % can_rx, 'R0']])
 
         if bitnum == 16 and self.fd:
-            self.putx([7, ['Bit rate switch: %d' % can_rx, 'BRS: %d' % can_rx, 'BRS']])
+            data = [7, ['Bit rate switch: %d' % can_rx,
+                        'BRS: %d' % can_rx, 'BRS']]
+
+            if self.brs:
+              from_bitrate = self.options['nominal_bitrate']
+              from_spp = self.options['nominal_sample_point']
+              to_bitrate = self.options['fd_bitrate']
+              to_spp = self.options['fd_sample_point']
+
+              self.putx_brs(from_bitrate, from_spp, to_bitrate, to_spp, data)
+            else:
+              self.putx(data)
 
         if bitnum == 17 and self.fd:
             self.putx([7, ['Error state indicator: %d' % can_rx, 'ESI: %d' % can_rx, 'ESI']])
@@ -474,8 +496,18 @@ class Decoder(srd.Decoder):
                            'RB0: %d' % can_rx, 'RB0']])
 
         elif bitnum == 35 and self.fd:
-            self.putx([7, ['Bit rate switch: %d' % can_rx,
-                           'BRS: %d' % can_rx, 'BRS']])
+            data = [7, ['Bit rate switch: %d' % can_rx,
+                        'BRS: %d' % can_rx, 'BRS']]
+
+            if self.brs:
+                from_bitrate = self.options['nominal_bitrate']
+                from_spp = self.options['nominal_sample_point']
+                to_bitrate = self.options['fd_bitrate']
+                to_spp = self.options['fd_sample_point']
+
+                self.putx_brs(from_bitrate, from_spp, to_bitrate, to_spp, data)
+            else:
+                self.putx(data)
 
         elif bitnum == 36 and self.fd:
             self.putx([7, ['Error state indicator: %d' % can_rx,
@@ -529,7 +561,23 @@ class Decoder(srd.Decoder):
             self.curbit += 1 # Increase self.curbit (bitnum is not affected).
             return
         else:
-            self.putx([17, [str(can_rx)]])
+            if self.fd and can_rx and (bitnum == 16 and self.frame_type == 'standard'
+                                    or bitnum == 35 and self.frame_type == 'extended'):
+                from_bitrate = self.options['nominal_bitrate']
+                from_spp = self.options['nominal_sample_point']
+                to_bitrate = self.options['fd_bitrate']
+                to_spp = self.options['fd_sample_point']
+
+                self.putx_brs(from_bitrate, from_spp, to_bitrate, to_spp, [17, [str(can_rx)]])
+            elif self.fd and self.brs and bitnum == (self.crc_start + self.crc_len):
+                from_bitrate = self.options['fd_bitrate']
+                from_spp = self.options['fd_sample_point']
+                to_bitrate = self.options['nominal_bitrate']
+                to_spp = self.options['nominal_sample_point']
+
+                self.putx_brs(from_bitrate, from_spp, to_bitrate, to_spp, [17, [str(can_rx)]])
+            else:
+                self.putx([17, [str(can_rx)]])
 
         # Bit 0: Start of frame (SOF) bit
         if bitnum == 0:

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -94,15 +94,15 @@ class Decoder(srd.Decoder):
         self.out_ann = self.register(srd.OUTPUT_ANN)
         self.out_python = self.register(srd.OUTPUT_PYTHON)
 
-    def set_bit_rate(self, bitrate):
+    def set_bit_rate(self, bitrate, sample_point):
         self.bit_width = float(self.samplerate) / float(bitrate)
-        self.sample_point = (self.bit_width / 100.0) * self.options['nominal_sample_point']
+        self.sample_point = (self.bit_width / 100.0) * sample_point
 
     def set_nominal_bitrate(self):
-        self.set_bit_rate(self.options['nominal_bitrate'])
+        self.set_bit_rate(self.options['nominal_bitrate'], self.options['nominal_sample_point'])
 
     def set_fd_bitrate(self):
-        self.set_bit_rate(self.options['fd_bitrate'])
+        self.set_bit_rate(self.options['fd_bitrate'], self.options['fd_sample_point'])
 
     def set_dlc_and_crc_len(self, dlc):
         self.dlc = dlc

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -53,7 +53,7 @@ class Decoder(srd.Decoder):
     options = (
         {'id': 'nominal_bitrate', 'desc': 'Nominal bitrate (bits/s)', 'default': 1000000},
         {'id': 'fd_bitrate', 'desc': 'FD bitrate (bits/s)', 'default': 2000000},
-        {'id': 'sample_point', 'desc': 'Sample point (%)', 'default': 70.0},
+        {'id': 'nominal_sample_point', 'desc': 'Nominal sample point (%)', 'default': 70.0},
     )
     annotations = (
         ('data', 'Payload data'),
@@ -95,7 +95,7 @@ class Decoder(srd.Decoder):
 
     def set_bit_rate(self, bitrate):
         self.bit_width = float(self.samplerate) / float(bitrate)
-        self.sample_point = (self.bit_width / 100.0) * self.options['sample_point']
+        self.sample_point = (self.bit_width / 100.0) * self.options['nominal_sample_point']
 
     def set_nominal_bitrate(self):
         self.set_bit_rate(self.options['nominal_bitrate'])
@@ -118,7 +118,7 @@ class Decoder(srd.Decoder):
         if key == srd.SRD_CONF_SAMPLERATE:
             self.samplerate = value
             self.bit_width = float(self.samplerate) / float(self.options['nominal_bitrate'])
-            self.sample_point = (self.bit_width / 100.0) * self.options['sample_point']
+            self.sample_point = (self.bit_width / 100.0) * self.options['nominal_sample_point']
 
     # Generic helper for CAN bit annotations.
     def putg(self, ss, es, data):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -98,6 +98,11 @@ class Decoder(srd.Decoder):
         self.bit_width = float(self.samplerate) / float(bitrate)
         self.sample_point = (self.bit_width / 100.0) * sample_point
 
+        if self.fd:
+            # Set virtual dom edge after the bit where bitrate switch happened, to adjust sample grid to new bitrate
+            self.dom_edge_bcount = self.curbit + 1
+            self.dom_edge_snum = self.samplenum + self.bit_width - self.sample_point
+
     def set_nominal_bitrate(self):
         self.set_bit_rate(self.options['nominal_bitrate'], self.options['nominal_sample_point'])
 
@@ -593,8 +598,7 @@ class Decoder(srd.Decoder):
                             self.brs = True if can_rx else False
 
                             if self.brs:
-                              self.dom_edge_seen(force=True)
-                              self.set_fd_bitrate()
+                                self.set_fd_bitrate()
 
                         # FD-CRC delimiter
                         elif self.brs and bitnum == (self.crc_start + self.crc_len):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -64,10 +64,11 @@ class Decoder(srd.Decoder):
         ('stuff-bit', 'Stuff bit'),
         ('warning', 'Warning'),
         ('bit', 'Bit'),
+        ('sbc', 'Stuff bit count')
     )
     annotation_rows = (
         ('bits', 'Bits', (15, 17)),
-        ('fields', 'Fields', tuple(range(15))),
+        ('fields', 'Fields', tuple(range(15)) + (18,)),
         ('warnings', 'Warnings', (16,)),
     )
 
@@ -97,9 +98,9 @@ class Decoder(srd.Decoder):
 
         if self.fd:
             if dlc2len(self.dlc) < 16:
-                self.crc_len = 21 # 17 + SBC bits
+                self.crc_len = 17
             else:
-                self.crc_len = 25 # 21 + SBC bits
+                self.crc_len = 21
         else:
             self.crc_len = 15
 
@@ -188,7 +189,7 @@ class Decoder(srd.Decoder):
 
         # Bit stuffing is not applied to the CRC delimiter, ACK field,
         # or End-of-Frame (EOF) field:
-        if cur_bit > self.last_databit + self.crc_len:
+        if cur_bit > self.crc_start + self.crc_len - 1:
             self.last_bit_was_stuff_bit = False
             return False
 
@@ -223,22 +224,28 @@ class Decoder(srd.Decoder):
     # Returns True if the frame ended (EOF), False otherwise.
     def decode_frame_end(self, can_rx, bitnum):
 
-        # Remember start of CRC sequence (see below).
+        # Remember start of Non-FD CRC sequence or FD-SBC field (see below).
         if bitnum == (self.last_databit + 1):
+            self.ss_block = self.samplenum
+        elif self.fd and bitnum == (self.last_databit + 4):
+            # SBC field
+            x = self.last_databit + 1
+            sbc_bits = self.bits[x:x + self.last_databit + 4]
+            sbc = bitpack_msb(sbc_bits)
+
+            self.putb([18, ['Raw stuff bit count: %d' % sbc,
+                            'rSBC: %d' % sbc, 'SBC']])
+
+        # Remember start of FD-CRC sequence (see below).
+        elif self.fd and bitnum == (self.last_databit + 4 + 1):
             self.ss_block = self.samplenum
 
         # CRC sequence (15 bits, 17 bits or 21 bits)
-        elif bitnum == (self.last_databit + self.crc_len):
-            if self.fd:
-                if dlc2len(self.dlc) < 16:
-                    crc_type = "CRC-17"
-                else:
-                    crc_type = "CRC-21"
-            else:
-                crc_type = "CRC-15"
-
-            x = self.last_databit + 1
+        elif bitnum == (self.crc_start - 1 + self.crc_len):
+            x = self.crc_start
             crc_bits = self.bits[x:x + self.crc_len + 1]
+
+            crc_type = "CRC-%d" % self.crc_len
             self.crc = bitpack_msb(crc_bits)
             self.putb([11, ['%s sequence: 0x%04x' % (crc_type, self.crc),
                             '%s: 0x%04x' % (crc_type, self.crc), '%s' % crc_type]])
@@ -246,7 +253,7 @@ class Decoder(srd.Decoder):
                 self.putb([16, ['CRC is invalid']])
 
         # CRC delimiter bit (recessive)
-        elif bitnum == (self.last_databit + self.crc_len + 1):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 1):
             self.putx([12, ['CRC delimiter: %d' % can_rx,
                             'CRC d: %d' % can_rx, 'CRC d']])
             if can_rx != 1:
@@ -256,23 +263,23 @@ class Decoder(srd.Decoder):
                 self.set_nominal_bitrate()
 
         # ACK slot bit (dominant: ACK, recessive: NACK)
-        elif bitnum == (self.last_databit + self.crc_len + 2):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 2):
             ack = 'ACK' if can_rx == 0 else 'NACK'
             self.putx([13, ['ACK slot: %s' % ack, 'ACK s: %s' % ack, 'ACK s']])
 
         # ACK delimiter bit (recessive)
-        elif bitnum == (self.last_databit + self.crc_len + 3):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 3):
             self.putx([14, ['ACK delimiter: %d' % can_rx,
                             'ACK d: %d' % can_rx, 'ACK d']])
             if can_rx != 1:
                 self.putx([16, ['ACK delimiter must be a recessive bit']])
 
         # Remember start of EOF (see below).
-        elif bitnum == (self.last_databit + self.crc_len + 4):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 4):
             self.ss_block = self.samplenum
 
         # End of frame (EOF), 7 recessive bits
-        elif bitnum == (self.last_databit + self.crc_len + 10):
+        elif bitnum == (self.crc_start - 1 + self.crc_len + 3 + 7):
             self.putb([2, ['End of frame', 'EOF', 'E']])
             if self.rawbits[-7:] != [1, 1, 1, 1, 1, 1, 1]:
                 self.putb([16, ['End of frame (EOF) must be 7 recessive bits']])

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -52,7 +52,7 @@ class Decoder(srd.Decoder):
     )
     options = (
         {'id': 'nominal_bitrate', 'desc': 'Nominal bitrate (bits/s)', 'default': 1000000},
-        {'id': 'fast_bitrate', 'desc': 'Fast bitrate (bits/s)', 'default': 2000000},
+        {'id': 'fd_bitrate', 'desc': 'FD bitrate (bits/s)', 'default': 2000000},
         {'id': 'sample_point', 'desc': 'Sample point (%)', 'default': 70.0},
     )
     annotations = (
@@ -100,8 +100,8 @@ class Decoder(srd.Decoder):
     def set_nominal_bitrate(self):
         self.set_bit_rate(self.options['nominal_bitrate'])
 
-    def set_fast_bitrate(self):
-        self.set_bit_rate(self.options['fast_bitrate'])
+    def set_fd_bitrate(self):
+        self.set_bit_rate(self.options['fd_bitrate'])
 
     def set_dlc_and_crc_len(self, dlc):
         self.dlc = dlc
@@ -513,7 +513,7 @@ class Decoder(srd.Decoder):
             if bitnum == 16 and self.frame_type == 'standard' \
                     or bitnum == 35 and self.frame_type == 'extended':
                 self.dom_edge_seen(force=True)
-                self.set_fast_bitrate()
+                self.set_fd_bitrate()
 
         # If this is a stuff bit, remove it from self.bits and ignore it.
         if self.is_stuff_bit():

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -220,6 +220,15 @@ class Decoder(srd.Decoder):
         self.last_bit_was_stuff_bit = True
         return True
 
+    def is_valid_parity(self, num, given_parity_bit):
+        calculated_parity_bit = 0
+
+        while num:
+            calculated_parity_bit ^= num & 1
+            num >>= 1
+
+        return calculated_parity_bit == given_parity_bit
+
     def is_valid_crc(self, crc_bits):
         return True # TODO
 
@@ -243,7 +252,12 @@ class Decoder(srd.Decoder):
             sbc_bits = self.bits[x:x + self.last_databit + 4]
             p_gray_sbc = bitpack_msb(sbc_bits)
 
+            parity = p_gray_sbc & 1
             gray_sbc = p_gray_sbc >> 1
+
+            if not self.is_valid_parity(gray_sbc, parity):
+                self.putb([16, ['Parity is invalid']])
+
             sbc = gray2num(gray_sbc) # Number of stuff bits modulo 8
 
             self.putb([18, ['Stuff bit count: %d' % sbc,

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -288,9 +288,6 @@ class Decoder(srd.Decoder):
             if can_rx != 1:
                 self.putx([16, ['CRC delimiter must be a recessive bit']])
 
-            if self.fd:
-                self.set_nominal_bitrate()
-
         # ACK slot bit (dominant: ACK, recessive: NACK)
         elif bitnum == (self.crc_start - 1 + self.crc_len + 2):
             ack = 'ACK' if can_rx == 0 else 'NACK'
@@ -598,5 +595,9 @@ class Decoder(srd.Decoder):
                             if self.brs:
                               self.dom_edge_seen(force=True)
                               self.set_fd_bitrate()
+
+                        # FD-CRC delimiter
+                        elif self.brs and bitnum == (self.crc_start + self.crc_len):
+                            self.set_nominal_bitrate()
 
                     self.handle_bit(bitnum, can_rx)

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -503,12 +503,9 @@ class Decoder(srd.Decoder):
 
         return False
 
-    def handle_bit(self, can_rx):
+    def handle_bit(self, bitnum, can_rx):
         self.rawbits.append(can_rx)
         self.bits.append(can_rx)
-
-        # Get the index of the current CAN frame bit (without stuff bits).
-        bitnum = len(self.bits) - 1
 
         if self.fd and can_rx:
             if bitnum == 16 and self.frame_type == 'standard' \
@@ -588,10 +585,12 @@ class Decoder(srd.Decoder):
                 self.dom_edge_seen(force = True)
                 self.state = 'GET BITS'
             elif self.state == 'GET BITS':
+                bitnum = len(self.bits) # Get the index of the current CAN frame bit (without stuff bits).
+
                 # Wait until we're in the correct bit/sampling position.
                 pos = self.get_sample_point(self.curbit)
                 (can_rx,) = self.wait([{'skip': pos - self.samplenum}, {0: 'f'}])
                 if self.matched[1]:
                     self.dom_edge_seen()
                 if self.matched[0]:
-                    self.handle_bit(can_rx)
+                    self.handle_bit(bitnum, can_rx)

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -140,6 +140,7 @@ class Decoder(srd.Decoder):
         self.bits = [] # Only actual CAN frame bits (no stuff bits)
         self.curbit = 0 # Current bit of CAN frame (bit 0 == SOF)
         self.last_databit = 999 # Positive value that bitnum+x will never match
+        self.crc_start = 999
         self.ss_block = None
         self.ss_bit12 = None
         self.ss_bit32 = None
@@ -332,6 +333,11 @@ class Decoder(srd.Decoder):
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)
+            self.crc_start = self.last_databit + 1
+
+            if self.fd:
+                self.crc_start += 4 # Skip SBC field
+
             if self.dlc > 8 and not self.fd:
                 self.putb([16, ['Data length code (DLC) > 8 is not allowed']])
 
@@ -434,6 +440,10 @@ class Decoder(srd.Decoder):
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)
+            self.crc_start = self.last_databit + 1
+
+            if self.fd:
+                self.crc_start += 4 # Skip SBC field
 
         # Remember all databyte bits, except the very last one.
         elif bitnum in range(self.dlc_start + 4, self.last_databit):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -27,6 +27,16 @@ class SamplerateError(Exception):
 def dlc2len(dlc):
     return [0, 1, 2, 3, 4, 5, 6, 7, 8, 12, 16, 20, 24, 32, 48, 64][dlc]
 
+def gray2num(gray_code):
+    num = gray_code
+    mask = gray_code
+
+    while mask:
+        mask >>= 1
+        num ^= mask
+
+    return num
+
 class Decoder(srd.Decoder):
     api_version = 3
     id = 'can'
@@ -231,10 +241,13 @@ class Decoder(srd.Decoder):
             # SBC field
             x = self.last_databit + 1
             sbc_bits = self.bits[x:x + self.last_databit + 4]
-            sbc = bitpack_msb(sbc_bits)
+            p_gray_sbc = bitpack_msb(sbc_bits)
 
-            self.putb([18, ['Raw stuff bit count: %d' % sbc,
-                            'rSBC: %d' % sbc, 'SBC']])
+            gray_sbc = p_gray_sbc >> 1
+            sbc = gray2num(gray_sbc) # Number of stuff bits modulo 8
+
+            self.putb([18, ['Stuff bit count: %d' % sbc,
+                            'SBC: %d' % sbc, 'SBC']])
 
         # Remember start of FD-CRC sequence (see below).
         elif self.fd and bitnum == (self.last_databit + 4 + 1):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -92,6 +92,17 @@ class Decoder(srd.Decoder):
     def set_fast_bitrate(self):
         self.set_bit_rate(self.options['fast_bitrate'])
 
+    def set_dlc_and_crc_len(self, dlc):
+        self.dlc = dlc
+
+        if self.fd:
+            if dlc2len(self.dlc) < 16:
+                self.crc_len = 27 # 17 + SBC + stuff bits
+            else:
+                self.crc_len = 32 # 21 + SBC + stuff bits
+        else:
+            self.crc_len = 15
+
     def metadata(self, key, value):
         if key == srd.SRD_CONF_SAMPLERATE:
             self.samplerate = value
@@ -185,13 +196,6 @@ class Decoder(srd.Decoder):
         # Remember start of CRC sequence (see below).
         if bitnum == (self.last_databit + 1):
             self.ss_block = self.samplenum
-            if self.fd:
-                if dlc2len(self.dlc) < 16:
-                    self.crc_len = 27 # 17 + SBC + stuff bits
-                else:
-                    self.crc_len = 32 # 21 + SBC + stuff bits
-            else:
-                self.crc_len = 15
 
         # CRC sequence (15 bits, 17 bits or 21 bits)
         elif bitnum == (self.last_databit + self.crc_len):
@@ -295,7 +299,7 @@ class Decoder(srd.Decoder):
 
         # Bits 15-18: Data length code (DLC), in number of bytes (0-8).
         elif bitnum == self.dlc_start + 3:
-            self.dlc = bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4])
+            self.set_dlc_and_crc_len(bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4]))
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)
@@ -397,7 +401,7 @@ class Decoder(srd.Decoder):
 
         # Bits 35-38: Data length code (DLC), in number of bytes (0-8).
         elif bitnum == self.dlc_start + 3:
-            self.dlc = bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4])
+            self.set_dlc_and_crc_len(bitpack_msb(self.bits[self.dlc_start:self.dlc_start + 4]))
             self.putb([10, ['Data length code: %d' % self.dlc,
                             'DLC: %d' % self.dlc, 'DLC']])
             self.last_databit = self.dlc_start + 3 + (dlc2len(self.dlc) * 8)

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -97,9 +97,9 @@ class Decoder(srd.Decoder):
 
         if self.fd:
             if dlc2len(self.dlc) < 16:
-                self.crc_len = 27 # 17 + SBC + stuff bits
+                self.crc_len = 21 # 17 + SBC bits
             else:
-                self.crc_len = 32 # 21 + SBC + stuff bits
+                self.crc_len = 25 # 21 + SBC bits
         else:
             self.crc_len = 15
 
@@ -148,6 +148,8 @@ class Decoder(srd.Decoder):
         self.rtr_type = None
         self.fd = False
         self.rtr = None
+        self.last_bit_was_stuff_bit = False
+        self.crc_len = 15
 
     # Poor man's clock synchronization. Use signal edges which change to
     # dominant state in rather simple ways. This naive approach is neither
@@ -166,17 +168,44 @@ class Decoder(srd.Decoder):
         return int(samplenum)
 
     def is_stuff_bit(self):
-        # CAN uses NRZ encoding and bit stuffing.
-        # After 5 identical bits, a stuff bit of opposite value is added.
-        # But not in the CRC delimiter, ACK, and end of frame fields.
-        if len(self.bits) > self.last_databit + 17:
+        # CAN uses NRZ encoding (dynamic bit stuffing).
+        # After five consecutive bits of identical value, a stuff bit of the
+        # opposite polarity is inserted.
+        #
+        # In CAN-FD frames, additional fixed bit stuffing is used for the CRC field.
+        # This fixed stuffing begins one bit before the CRC field, regardless of
+        # whether five identical bits have occurred.
+
+        # If a dynamic stuff bit and a fixed stuff bit would be inserted at the
+        # same position, only the fixed stuff bit is inserted. In this case,
+        # only a single stuff bit is inserted:
+        if self.last_bit_was_stuff_bit:
+            self.last_bit_was_stuff_bit = False
             return False
-        last_6_bits = self.rawbits[-6:]
-        if last_6_bits not in ([0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 1, 0]):
+
+        cur_bit = len(self.bits) - 1
+
+        # Bit stuffing is not applied to the CRC delimiter, ACK field,
+        # or End-of-Frame (EOF) field:
+        if cur_bit > self.last_databit + self.crc_len:
+            self.last_bit_was_stuff_bit = False
             return False
+
+        if self.fd and cur_bit > self.last_databit:
+            # Within the CAN-FD CRC field, a fixed stuff bit is inserted after every fourth bit:
+            if (cur_bit - self.last_databit - 1) % 4 != 0:
+                self.last_bit_was_stuff_bit = False
+                return False
+        else:
+            # NRZ dynamic bit stuffing:
+            last_6_bits = self.rawbits[-6:]
+            if last_6_bits not in ([0, 0, 0, 0, 0, 1], [1, 1, 1, 1, 1, 0]):
+                self.last_bit_was_stuff_bit = False
+                return False
 
         # Stuff bit. Keep it in self.rawbits, but drop it from self.bits.
         self.bits.pop() # Drop last bit.
+        self.last_bit_was_stuff_bit = True
         return True
 
     def is_valid_crc(self, crc_bits):

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -131,6 +131,19 @@ class Decoder(srd.Decoder):
         left, right = int(self.sample_point), int(self.bit_width - self.sample_point)
         self.put(ss - left, es + right, self.out_ann, data)
 
+    # Single-CAN-bit annotation for a bitrate switch bit using the current samplenum.
+    def putx_brs(self, from_bitrate, from_spp, to_bitrate, to_spp, data):
+        from_samples_per_bit = float(self.samplerate) / float(from_bitrate)
+        from_spp_sample_no = (from_samples_per_bit / 100.0) * from_spp
+
+        to_samples_per_bit = float(self.samplerate) / float(to_bitrate)
+        to_spp_sample_no = (to_samples_per_bit / 100.0) * to_spp
+
+        num_samples_brs_bit = from_spp_sample_no + to_samples_per_bit - to_spp_sample_no
+
+        left, right = int(from_spp_sample_no), int(num_samples_brs_bit - from_spp_sample_no)
+        self.put(self.samplenum - left, self.samplenum + right, self.out_ann, data)
+
     # Single-CAN-bit annotation using the current samplenum.
     def putx(self, data):
         self.putg(self.samplenum, self.samplenum, data)

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -2,7 +2,7 @@
 ## This file is part of the libsigrokdecode project.
 ##
 ## Copyright (C) 2012-2013 Uwe Hermann <uwe@hermann-uwe.de>
-## Copyright (C) 2019 Stephan Thiele <stephan.thiele@mailbox.org>
+## Copyright (C) 2019-2026 Stephan Thiele <stephan.thiele@mailbox.org>
 ##
 ## This program is free software; you can redistribute it and/or modify
 ## it under the terms of the GNU General Public License as published by

--- a/decoders/can/pd.py
+++ b/decoders/can/pd.py
@@ -54,6 +54,7 @@ class Decoder(srd.Decoder):
         {'id': 'nominal_bitrate', 'desc': 'Nominal bitrate (bits/s)', 'default': 1000000},
         {'id': 'fd_bitrate', 'desc': 'FD bitrate (bits/s)', 'default': 2000000},
         {'id': 'nominal_sample_point', 'desc': 'Nominal sample point (%)', 'default': 70.0},
+        {'id': 'fd_sample_point', 'desc': 'FD sample point (%)', 'default': 70.0},
     )
     annotations = (
         ('data', 'Payload data'),


### PR DESCRIPTION
**This PR builds on https://github.com/sigrokproject/libsigrokdecode/pull/131. Please do not review or merge, until https://github.com/sigrokproject/libsigrokdecode/pull/131 has been merged!**

# Summary

In this PR, CAN-FD bitrate switch decoding and annotion appearance are fixed.

In order to do this, the following steps have been done (More details below):
- Add "FD Sample Point (%)" option, as FD fast rate has it's own sample point. Currently only the nominal sample point can be set and the same value is also used for FD bitrate.
- Bitrate switch handling is done properly by defining forced DOM edge to correct location.
- Annotation appearance of BRS bit and CRC-Delimiter (On FD-Frames) are fixed.

# Current issues

Currently bitrate switch for CAN-FD is not decoded properly which may break decoding under certain circumstances. Also the annotation of BRS bit and CRC delimiter bit are not correct.

For the following images, the following settings were used:

```
Nominal bitrate: 1M
Nominal sample point: 75%
FD bitrate: 2M
FD sample point: 80%
Extended frame: No
BRS: Yes
11898-1 ISO-mode: On
ID: 0x42
Length: 8 bytes
Data is counting up from 0x00 to 0x07
```

BRS annotation has a gap and overlaps with next bit, if a nominal sample point of decoder is set to 75%:
<img width="1069" height="182" alt="image" src="https://github.com/user-attachments/assets/4581a659-a5e5-487a-8493-3ebd4213ab9b" />

After fix:
<img width="1069" height="182" alt="image" src="https://github.com/user-attachments/assets/4b3959b5-6d77-445b-bcbb-7561b7c960a9" />

CRC delimiter Annotation looks okayish but is incorrect (Gap to ACK slot should be around 160ns instead):
<img width="1739" height="199" alt="image" src="https://github.com/user-attachments/assets/40bc0acb-21c5-4cf0-b462-f7494bdac426" />

After fix:
<img width="1739" height="199" alt="image" src="https://github.com/user-attachments/assets/4dff197d-4996-4c71-8228-dc995eddb996" />

Decoding breaks, if ESI bit is set (DLC should be 8):
<img width="1201" height="149" alt="image" src="https://github.com/user-attachments/assets/1c3f162a-1e61-400d-ae41-9b000b600f12" />

After fix:
<img width="1201" height="149" alt="image" src="https://github.com/user-attachments/assets/532c3523-4ae2-4233-839a-e2f74efce1c3" />

Decoding breaks, if ACK slot is not set:
<img width="1854" height="204" alt="image" src="https://github.com/user-attachments/assets/b17e48ef-c0e8-42e0-96b8-7a2baf378a2c" />

After fix (Error frames are not decoded yet, but that's another issue):
<img width="1854" height="204" alt="image" src="https://github.com/user-attachments/assets/4ee2fe45-f455-49a0-93e5-67d64c25ac01" />

# The fixes

## Annotation

On CAN-FD, the bitrate is switched to FD bitrate at the sample point of `BRS` bit and switched back to nominal bitrate the sample point of CRC-Delimiter.

In the following example:
  - Nominal bitrate is 1Mbit/s with a sample point of 75%
  - FD bitrate is 2Mbit/s with a sample point of 80%
  - Sample rate of logic analyzer is 100Mhz.
 
The current annotation just uses the FD bitrate and the sample point of the nominal bitrate, which makes the annotation too small and, if the nominal sample point and FD sample point differ, slightly overlapping. The correct way is to calculate the combined bit length from nominal and FD phase is as follows:

Bit widths for nominal and FD bitrates are:
- 100 Mhz / 1Mbit/s -> 100 samples per bit
- 100 Mhz / 2Mbit/s -> 50 samples per bit

Total bit width of BRS bit: 100 samples/bit * 0.75 + 50 samples/bit * 0.20 -> 85 samples.

<img width="1422" height="151" alt="image" src="https://github.com/user-attachments/assets/a0f95316-9955-4662-98a6-9cd295b04d1c" />


For this task, the new annotation function `putx_brs` is introduced.

## Decoding

Currently, when the bitrate is switched at the sample point, the sample point is defined as a dom edge, which leads to wrong decoding behaviour, as the effective sample point is wrong until another dom edge has been reached and leads to proper resynchonization. Thus, the fix of this PR simply defines the end of the bit, where birate is switched, as dom edge (forced DOM edge), regardless if it is a falling or rising edge. That way sampling is properly adjusted to new bitrate.